### PR TITLE
feat: local SSL with auto-generated certificates for .test domains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,12 @@ Entry point: `main.go` → `cmd.Execute()` (Cobra CLI).
 ### Core packages (`internal/`)
 
 - **allocator** — Port allocation via FNV-32a hash on `"{project}/{instance}/{service}"`. An optional preferred_port can be specified per service; when omitted, the hash is the primary allocation method. Port range: 10000–39999 (port 15353 reserved for daemon DNS). Collisions resolved by linear probing with wraparound.
-- **registry** — Persistent JSON store at `~/.config/outport/registry.json`. Keys are `"{project}/{instance}"` (e.g., `"myapp/main"`, `"myapp/bxcf"`). Each allocation stores ports, hostnames, and protocols. Atomic writes via temp file + rename. Supports lookup by directory (`FindByDir`) and by project name (`FindByProject`).
+- **certmanager** — Local CA and server certificate lifecycle. Generates a CA (EC P-256, 10-year) during `outport setup`, creates per-hostname server certs on demand via TLS SNI callback, caches to disk (`~/.cache/outport/certs/`) and memory. Exports path helpers (`CACertPath`, `CAKeyPath`, `CertCacheDir`) used by `apply` and `open` to detect HTTPS availability.
+- **registry** — Persistent JSON store at `~/.local/share/outport/registry.json`. Keys are `"{project}/{instance}"` (e.g., `"myapp/main"`, `"myapp/bxcf"`). Each allocation stores ports, hostnames, and protocols. Atomic writes via temp file + rename. Supports lookup by directory (`FindByDir`) and by project name (`FindByProject`).
 - **config** — Loads/validates `.outport.yml`. Supports per-service env_file (string or array), preferred_port, protocol, hostname, and derived values (`${service.field}` and `${service.field:modifier}` templates with optional per-file overrides). `FindDir()` walks up from the current directory to locate the config. Validates env_var uniqueness per file, hostname format (must contain project name, requires http/https protocol), and derived value reference validity (service name + field + modifier).
 - **instance** — Resolves instance names for projects. First instance of a project is "main". Additional instances get random 4-character consonant codes (e.g., "bxcf"). Looks up the registry by directory to find existing instances. Provides name validation (lowercase alphanumeric + hyphens).
-- **daemon** — Long-running process providing DNS server (port 15353, resolves `*.test` to 127.0.0.1) and HTTP reverse proxy (port 80, routes requests by Host header to the correct service port). Watches the registry file for changes and rebuilds the route table automatically. Supports WebSocket proxying.
-- **platform** — macOS-specific integration for the daemon. Manages the LaunchAgent plist (`~/Library/LaunchAgents/`) and `/etc/resolver/test` file for `.test` domain resolution. Provides setup/teardown/load/unload operations.
+- **daemon** — Long-running process providing DNS server (port 15353, resolves `*.test` to 127.0.0.1), HTTP reverse proxy (port 80, 307 redirect to HTTPS when CA exists), and TLS reverse proxy (port 443, SNI-based cert selection). Watches the registry file for changes and rebuilds the route table automatically. Supports WebSocket proxying.
+- **platform** — macOS-specific integration for the daemon. Manages the LaunchAgent plist (`~/Library/LaunchAgents/`) and `/etc/resolver/test` file for `.test` domain resolution. Provides setup/teardown/load/unload operations and CA trust/untrust via macOS `security` CLI.
 - **dotenv** — Writes allocated ports and derived values into a fenced block (`# --- begin outport.dev ---` / `# --- end outport.dev ---`) at the bottom of `.env` files. User content outside the block is preserved. Managed vars in the user section are removed and relocated into the block. Also provides `RemoveBlock()` for cleanup.
 - **ui** — Lipgloss terminal styling constants.
 
@@ -48,8 +49,8 @@ Entry point: `main.go` → `cmd.Execute()` (Cobra CLI).
 - **gc** — Remove stale registry entries where the project directory no longer exists.
 - **rename** — Rename an instance of the current project. Updates hostnames and re-merges `.env` files.
 - **promote** — Promote the current instance to "main". Demotes the existing main instance to a generated code name. Updates hostnames for both instances.
-- **setup** — Install the `.test` DNS resolver and LaunchAgent daemon (macOS). Requires sudo for `/etc/resolver/test`.
-- **teardown** — Remove the DNS resolver and daemon. Reverse of setup.
+- **setup** — Install the `.test` DNS resolver, LaunchAgent daemon, and local CA for HTTPS. Requires sudo for `/etc/resolver/test`. Generates a CA certificate and adds it to the macOS login keychain trust store (GUI password prompt). Listens on ports 80 (HTTP->HTTPS redirect) and 443 (TLS proxy).
+- **teardown** — Remove the DNS resolver, daemon, CA certificate, and cached server certs. Reverse of setup.
 - **up** — Start the daemon (load the LaunchAgent).
 - **down** — Stop the daemon (unload the LaunchAgent).
 - **daemon** — (hidden) Run the DNS and proxy daemon directly. Invoked by launchd, not by users.
@@ -64,7 +65,9 @@ All commands support `--json` for machine-readable output. Each command has pair
 - **`.test` hostnames** — Services with `hostname` + `protocol: http/https` get `.test` domain hostnames (e.g., `myapp.test`). Non-main instances get suffixed hostnames (e.g., `myapp-bxcf.test`). Hostnames are globally unique across all registered projects.
 - **Template modifiers** — Derived values support `${service.field}` references. The `url` field resolves to the `.test` hostname URL (e.g., `http://myapp.test`). The `:direct` modifier gives the localhost URL with port (e.g., `http://localhost:3000`). Syntax: `${service.url}` vs `${service.url:direct}`.
 - **Fenced .env blocks** — Managed variables are written in a `# --- begin/end outport.dev ---` fenced section. User content outside the block is never touched. Vars claimed by Outport are removed from the user section and relocated into the block.
-- **Daemon architecture** — A LaunchAgent runs a DNS server (port 15353, `*.test` → 127.0.0.1) and HTTP reverse proxy (port 80, routes by Host header). The daemon watches the registry file and rebuilds routes on changes.
+- **Daemon architecture** — A LaunchAgent runs a DNS server (port 15353, `*.test` -> 127.0.0.1), HTTP reverse proxy (port 80), and TLS reverse proxy (port 443). When the CA is installed, port 80 issues 307 redirects to HTTPS. The daemon watches the registry file and rebuilds routes on changes.
+- **Automatic HTTPS** — When the CA is installed (after `outport setup`), all `.test` hostnames automatically get HTTPS. Port 80 redirects to HTTPS via 307. Port 443 terminates TLS and proxies to the backend over plain HTTP. `${service.url}` produces `https://` URLs when the CA exists. No per-service opt-in required.
+- **XDG directory layout** — Registry at `~/.local/share/outport/registry.json`, CA at `~/.local/share/outport/`, cert cache at `~/.cache/outport/certs/`. `~/.config/outport/` reserved for future global config.
 - **Error wrapping** — Uses `fmt.Errorf("context: %w", err)` throughout.
 
 ## Testing

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -9,6 +9,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/outport-app/outport/internal/allocator"
+	"github.com/outport-app/outport/internal/certmanager"
 	"github.com/outport-app/outport/internal/config"
 	"github.com/outport-app/outport/internal/portcheck"
 	"github.com/outport-app/outport/internal/registry"
@@ -110,17 +111,19 @@ func runApply(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := mergeEnvFiles(dir, cfg, ports, alloc.Hostnames); err != nil {
+	useHTTPS := certmanager.IsCAInstalled()
+
+	if err := mergeEnvFiles(dir, cfg, ports, alloc.Hostnames, useHTTPS); err != nil {
 		return err
 	}
 
-	resolvedDerived := resolveDerivedFromAlloc(cfg, ports, alloc.Hostnames)
+	resolvedDerived := resolveDerivedFromAlloc(cfg, ports, alloc.Hostnames, useHTTPS)
 	envFiles := mergedEnvFileList(cfg, resolvedDerived)
 
 	if jsonFlag {
-		return printApplyJSON(cmd, cfg, ctx.Instance, ports, alloc.Hostnames, resolvedDerived, envFiles)
+		return printApplyJSON(cmd, cfg, ctx.Instance, ports, alloc.Hostnames, resolvedDerived, envFiles, useHTTPS)
 	}
-	return printApplyStyled(cmd, cfg, ctx.Instance, serviceNames, ports, alloc.Hostnames, resolvedDerived, envFiles)
+	return printApplyStyled(cmd, cfg, ctx.Instance, serviceNames, ports, alloc.Hostnames, resolvedDerived, envFiles, useHTTPS)
 }
 
 // mergedEnvFileList returns the sorted list of env files that would be written
@@ -193,7 +196,8 @@ func computeProtocols(cfg *config.Config) map[string]string {
 
 // buildTemplateVars builds the template variable map from services and allocated ports.
 // Keys are "service.field" (e.g., "rails.port", "rails.hostname", "rails.url").
-func buildTemplateVars(cfg *config.Config, ports map[string]int, hostnames map[string]string) map[string]string {
+// When useHTTPS is true, .url uses https:// for .test hostnames.
+func buildTemplateVars(cfg *config.Config, ports map[string]int, hostnames map[string]string, useHTTPS bool) map[string]string {
 	vars := make(map[string]string)
 	for name, svc := range cfg.Services {
 		portStr := fmt.Sprintf("%d", ports[name])
@@ -204,6 +208,9 @@ func buildTemplateVars(cfg *config.Config, ports map[string]int, hostnames map[s
 			protocol := svc.Protocol
 			if protocol == "" {
 				protocol = "http"
+			}
+			if useHTTPS && (protocol == "http" || protocol == "https") {
+				protocol = "https"
 			}
 			vars[name+".url"] = fmt.Sprintf("%s://%s", protocol, h)
 			vars[name+".url:direct"] = fmt.Sprintf("http://localhost:%s", portStr)
@@ -220,11 +227,11 @@ func buildTemplateVars(cfg *config.Config, ports map[string]int, hostnames map[s
 
 // resolveDerivedFromAlloc resolves derived value templates using allocated ports.
 // Returns name → file → resolved value.
-func resolveDerivedFromAlloc(cfg *config.Config, ports map[string]int, hostnames map[string]string) map[string]map[string]string {
+func resolveDerivedFromAlloc(cfg *config.Config, ports map[string]int, hostnames map[string]string, useHTTPS bool) map[string]map[string]string {
 	if len(cfg.Derived) == 0 {
 		return nil
 	}
-	templateVars := buildTemplateVars(cfg, ports, hostnames)
+	templateVars := buildTemplateVars(cfg, ports, hostnames, useHTTPS)
 	return config.ResolveDerived(cfg.Derived, templateVars)
 }
 
@@ -266,21 +273,25 @@ type applyJSON struct {
 	EnvFiles []string               `json:"env_files"`
 }
 
-func serviceURL(protocol, hostname string, port int) string {
+func serviceURL(protocol, hostname string, port int, useHTTPS bool) string {
 	if protocol == "http" || protocol == "https" {
 		host := hostname
 		if host == "" {
 			host = "localhost"
 		}
+		scheme := protocol
+		if useHTTPS && strings.HasSuffix(host, ".test") {
+			scheme = "https"
+		}
 		if strings.HasSuffix(host, ".test") {
-			return fmt.Sprintf("%s://%s", protocol, host)
+			return fmt.Sprintf("%s://%s", scheme, host)
 		}
 		return fmt.Sprintf("%s://%s:%d", protocol, host, port)
 	}
 	return ""
 }
 
-func buildServiceMap(cfg *config.Config, ports map[string]int, hostnames map[string]string) map[string]svcJSON {
+func buildServiceMap(cfg *config.Config, ports map[string]int, hostnames map[string]string, useHTTPS bool) map[string]svcJSON {
 	services := make(map[string]svcJSON)
 	for name, svc := range cfg.Services {
 		hostname := resolvedHostname(svc, hostnames, name)
@@ -290,7 +301,7 @@ func buildServiceMap(cfg *config.Config, ports map[string]int, hostnames map[str
 			EnvVar:        svc.EnvVar,
 			Protocol:      svc.Protocol,
 			Hostname:      hostname,
-			URL:           serviceURL(svc.Protocol, hostname, ports[name]),
+			URL:           serviceURL(svc.Protocol, hostname, ports[name], useHTTPS),
 			EnvFiles:      svc.EnvFiles,
 		}
 	}
@@ -329,11 +340,11 @@ func buildDerivedMap(derived map[string]config.DerivedValue, resolved map[string
 	return m
 }
 
-func printApplyJSON(cmd *cobra.Command, cfg *config.Config, instanceName string, ports map[string]int, hostnames map[string]string, resolvedDerived map[string]map[string]string, envFiles []string) error {
+func printApplyJSON(cmd *cobra.Command, cfg *config.Config, instanceName string, ports map[string]int, hostnames map[string]string, resolvedDerived map[string]map[string]string, envFiles []string, useHTTPS bool) error {
 	out := applyJSON{
 		Project:  cfg.Name,
 		Instance: instanceName,
-		Services: buildServiceMap(cfg, ports, hostnames),
+		Services: buildServiceMap(cfg, ports, hostnames, useHTTPS),
 		Derived:  buildDerivedMap(cfg.Derived, resolvedDerived),
 		EnvFiles: envFiles,
 	}
@@ -351,12 +362,12 @@ func printHeader(w io.Writer, projectName, instanceName string) {
 	lipgloss.Fprintln(w)
 }
 
-func printApplyStyled(cmd *cobra.Command, cfg *config.Config, instanceName string, serviceNames []string, ports map[string]int, hostnames map[string]string, resolvedDerived map[string]map[string]string, envFiles []string) error {
+func printApplyStyled(cmd *cobra.Command, cfg *config.Config, instanceName string, serviceNames []string, ports map[string]int, hostnames map[string]string, resolvedDerived map[string]map[string]string, envFiles []string, useHTTPS bool) error {
 	w := cmd.OutOrStdout()
 
 	printHeader(w, cfg.Name, instanceName)
 
-	printFlatServices(w, cfg, serviceNames, ports, hostnames, nil)
+	printFlatServices(w, cfg, serviceNames, ports, hostnames, nil, useHTTPS)
 
 	if len(resolvedDerived) > 0 {
 		printDerivedValues(w, resolvedDerived)
@@ -421,13 +432,13 @@ func printDerivedValues(w io.Writer, resolved map[string]map[string]string) {
 	}
 }
 
-func printFlatServices(w io.Writer, cfg *config.Config, serviceNames []string, ports map[string]int, hostnames map[string]string, portStatus map[int]bool) {
+func printFlatServices(w io.Writer, cfg *config.Config, serviceNames []string, ports map[string]int, hostnames map[string]string, portStatus map[int]bool, useHTTPS bool) {
 	for _, svcName := range serviceNames {
-		printServiceLine(w, cfg, svcName, ports[svcName], hostnames, portStatus)
+		printServiceLine(w, cfg, svcName, ports[svcName], hostnames, portStatus, useHTTPS)
 	}
 }
 
-func printServiceLine(w io.Writer, cfg *config.Config, svcName string, port int, hostnames map[string]string, portStatus map[int]bool) {
+func printServiceLine(w io.Writer, cfg *config.Config, svcName string, port int, hostnames map[string]string, portStatus map[int]bool, useHTTPS bool) {
 	svc := cfg.Services[svcName]
 
 	status := ""
@@ -442,7 +453,7 @@ func printServiceLine(w io.Writer, cfg *config.Config, svcName string, port int,
 	hostname := resolvedHostname(svc, hostnames, svcName)
 
 	extra := ""
-	if u := serviceURL(svc.Protocol, hostname, port); u != "" {
+	if u := serviceURL(svc.Protocol, hostname, port, useHTTPS); u != "" {
 		extra = "  " + ui.UrlStyle.Render(u)
 	} else if hostname != "" {
 		extra = "  " + ui.HostnameStyle.Render(hostname)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -404,7 +404,7 @@ func TestStatus_StaleProjectMarkedNotFound(t *testing.T) {
 	jsonFlag = false
 
 	// Create a registry with a stale entry (nonexistent dir)
-	regPath := filepath.Join(home, ".config", "outport", "registry.json")
+	regPath := filepath.Join(home, ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -444,7 +444,7 @@ func TestStatus_StaleProjectInJSON(t *testing.T) {
 	jsonFlag = false
 
 	// Create a registry with a stale entry (directory gone)
-	regPath := filepath.Join(home, ".config", "outport", "registry.json")
+	regPath := filepath.Join(home, ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -482,7 +482,7 @@ func TestGC_RemovesStaleEntries(t *testing.T) {
 	jsonFlag = false
 
 	// Manually create a registry with a stale entry
-	regPath := filepath.Join(home, ".config", "outport", "registry.json")
+	regPath := filepath.Join(home, ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -525,7 +525,7 @@ func TestGC_NoStaleEntries(t *testing.T) {
 	t.Chdir(projectDir)
 	jsonFlag = false
 
-	regPath := filepath.Join(home, ".config", "outport", "registry.json")
+	regPath := filepath.Join(home, ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -555,7 +555,7 @@ func TestGC_RemovesMissingConfig(t *testing.T) {
 	t.Chdir(projectDir)
 	jsonFlag = false
 
-	regPath := filepath.Join(home, ".config", "outport", "registry.json")
+	regPath := filepath.Join(home, ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -617,7 +617,7 @@ func TestStatus_MissingConfigMarkedStale(t *testing.T) {
 	t.Chdir(projectDir)
 	jsonFlag = false
 
-	regPath := filepath.Join(home, ".config", "outport", "registry.json")
+	regPath := filepath.Join(home, ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -900,7 +900,7 @@ func TestRename_Success(t *testing.T) {
 	}
 
 	// Verify registry has new key with correct hostnames
-	regPath := filepath.Join(os.Getenv("HOME"), ".config", "outport", "registry.json")
+	regPath := filepath.Join(os.Getenv("HOME"), ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -1036,7 +1036,7 @@ func TestPromote_Success(t *testing.T) {
 	}
 
 	// Verify registry: promoted instance is now "main"
-	regPath := filepath.Join(home, ".config", "outport", "registry.json")
+	regPath := filepath.Join(home, ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -1150,7 +1150,7 @@ func TestApply_WithHostnames(t *testing.T) {
 	}
 
 	// Verify registry contains hostnames and protocols
-	regPath := filepath.Join(os.Getenv("HOME"), ".config", "outport", "registry.json")
+	regPath := filepath.Join(os.Getenv("HOME"), ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)
@@ -1265,7 +1265,7 @@ services:
 	os.Mkdir(filepath.Join(dir4, ".git"), 0755)
 
 	// Directly set up a registry entry that will cause a conflict
-	regPath := filepath.Join(home, ".config", "outport", "registry.json")
+	regPath := filepath.Join(home, ".local", "share", "outport", "registry.json")
 	reg, err := registry.Load(regPath)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/outport-app/outport/internal/certmanager"
+	"github.com/outport-app/outport/internal/config"
 	"github.com/outport-app/outport/internal/registry"
 )
 
@@ -1395,19 +1397,78 @@ derived:
 }
 
 func TestServiceURL(t *testing.T) {
-	if url := serviceURL("http", "", 3000); url != "http://localhost:3000" {
-		t.Errorf("serviceURL(http, '', 3000) = %q, want http://localhost:3000", url)
+	if url := serviceURL("http", "", 3000, false); url != "http://localhost:3000" {
+		t.Errorf("serviceURL(http, '', 3000, false) = %q, want http://localhost:3000", url)
 	}
-	if url := serviceURL("https", "", 8443); url != "https://localhost:8443" {
-		t.Errorf("serviceURL(https, '', 8443) = %q, want https://localhost:8443", url)
+	if url := serviceURL("https", "", 8443, false); url != "https://localhost:8443" {
+		t.Errorf("serviceURL(https, '', 8443, false) = %q, want https://localhost:8443", url)
 	}
-	if url := serviceURL("http", "myapp.localhost", 3000); url != "http://myapp.localhost:3000" {
-		t.Errorf("serviceURL(http, myapp.localhost, 3000) = %q, want http://myapp.localhost:3000", url)
+	if url := serviceURL("http", "myapp.localhost", 3000, false); url != "http://myapp.localhost:3000" {
+		t.Errorf("serviceURL(http, myapp.localhost, 3000, false) = %q, want http://myapp.localhost:3000", url)
 	}
-	if url := serviceURL("tcp", "", 5432); url != "" {
-		t.Errorf("serviceURL(tcp, '', 5432) = %q, want empty", url)
+	if url := serviceURL("tcp", "", 5432, false); url != "" {
+		t.Errorf("serviceURL(tcp, '', 5432, false) = %q, want empty", url)
 	}
-	if url := serviceURL("", "", 6379); url != "" {
-		t.Errorf("serviceURL('', '', 6379) = %q, want empty", url)
+	if url := serviceURL("", "", 6379, false); url != "" {
+		t.Errorf("serviceURL('', '', 6379, false) = %q, want empty", url)
+	}
+	// With useHTTPS=true, .test hostnames get https://
+	if url := serviceURL("http", "myapp.test", 3000, true); url != "https://myapp.test" {
+		t.Errorf("serviceURL(http, myapp.test, 3000, true) = %q, want https://myapp.test", url)
+	}
+	// Without useHTTPS, .test hostnames keep original protocol
+	if url := serviceURL("http", "myapp.test", 3000, false); url != "http://myapp.test" {
+		t.Errorf("serviceURL(http, myapp.test, 3000, false) = %q, want http://myapp.test", url)
+	}
+}
+
+func TestBuildTemplateVarsHTTPS(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dataDir := filepath.Join(home, ".local", "share", "outport")
+	os.MkdirAll(dataDir, 0755)
+	certmanager.GenerateCA(
+		filepath.Join(dataDir, "ca-cert.pem"),
+		filepath.Join(dataDir, "ca-key.pem"),
+	)
+
+	cfg := &config.Config{
+		Name: "myapp",
+		Services: map[string]config.Service{
+			"rails": {EnvVar: "PORT", Protocol: "http", Hostname: "myapp.test"},
+		},
+	}
+	ports := map[string]int{"rails": 3000}
+	hostnames := map[string]string{"rails": "myapp.test"}
+
+	useHTTPS := certmanager.IsCAInstalled()
+	vars := buildTemplateVars(cfg, ports, hostnames, useHTTPS)
+
+	if vars["rails.url"] != "https://myapp.test" {
+		t.Errorf("rails.url = %q, want %q", vars["rails.url"], "https://myapp.test")
+	}
+	if vars["rails.url:direct"] != "http://localhost:3000" {
+		t.Errorf("rails.url:direct = %q, want %q", vars["rails.url:direct"], "http://localhost:3000")
+	}
+}
+
+func TestBuildTemplateVarsHTTP(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home) // No CA here
+
+	cfg := &config.Config{
+		Name: "myapp",
+		Services: map[string]config.Service{
+			"rails": {EnvVar: "PORT", Protocol: "http", Hostname: "myapp.test"},
+		},
+	}
+	ports := map[string]int{"rails": 3000}
+	hostnames := map[string]string{"rails": "myapp.test"}
+
+	useHTTPS := certmanager.IsCAInstalled()
+	vars := buildTemplateVars(cfg, ports, hostnames, useHTTPS)
+
+	if vars["rails.url"] != "http://myapp.test" {
+		t.Errorf("rails.url = %q, want %q", vars["rails.url"], "http://myapp.test")
 	}
 }

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os/signal"
 	"syscall"
 
+	"github.com/outport-app/outport/internal/certmanager"
 	"github.com/outport-app/outport/internal/daemon"
 	"github.com/outport-app/outport/internal/registry"
 	"github.com/spf13/cobra"
@@ -36,14 +38,33 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		RegistryPath: regPath,
 	}
 
-	// Try launchd socket activation first (darwin only)
-	listener, err := activateLaunchdSocket()
-	if err == nil && listener != nil {
-		cfg.Listener = listener
-		cfg.ProxyAddr = listener.Addr().String()
+	// Try launchd HTTP socket activation (darwin only)
+	if httpLn, err := activateLaunchdHTTPSocket(); err == nil && httpLn != nil {
+		cfg.HTTPListener = httpLn
+		cfg.ProxyAddr = httpLn.Addr().String()
 	} else {
-		// Fall back to direct binding
 		cfg.ProxyAddr = fmt.Sprintf(":%d", daemonPort)
+	}
+
+	// Try launchd HTTPS socket activation (darwin only)
+	if httpsLn, err := activateLaunchdHTTPSSocket(); err == nil && httpsLn != nil {
+		cfg.HTTPSListener = httpsLn
+	}
+
+	// Wire TLS if the CA is installed
+	if certmanager.IsCAInstalled() {
+		caCertPath, _ := certmanager.CACertPath()
+		caKeyPath, _ := certmanager.CAKeyPath()
+		cacheDir, _ := certmanager.CertCacheDir()
+
+		store, err := certmanager.NewCertStore(caCertPath, caKeyPath, cacheDir)
+		if err != nil {
+			return fmt.Errorf("initializing cert store: %w", err)
+		}
+
+		cfg.TLSConfig = &tls.Config{
+			GetCertificate: store.GetCertificate,
+		}
 	}
 
 	d, err := daemon.New(cfg)

--- a/cmd/daemon_darwin.go
+++ b/cmd/daemon_darwin.go
@@ -8,6 +8,10 @@ import (
 	launchd "github.com/bored-engineer/go-launchd"
 )
 
-func activateLaunchdSocket() (net.Listener, error) {
-	return launchd.Activate("Socket")
+func activateLaunchdHTTPSocket() (net.Listener, error) {
+	return launchd.Activate("HTTPSocket")
+}
+
+func activateLaunchdHTTPSSocket() (net.Listener, error) {
+	return launchd.Activate("HTTPSSocket")
 }

--- a/cmd/daemon_other.go
+++ b/cmd/daemon_other.go
@@ -7,6 +7,10 @@ import (
 	"net"
 )
 
-func activateLaunchdSocket() (net.Listener, error) {
+func activateLaunchdHTTPSocket() (net.Listener, error) {
+	return nil, fmt.Errorf("launchd not available on this platform")
+}
+
+func activateLaunchdHTTPSSocket() (net.Listener, error) {
 	return nil, fmt.Errorf("launchd not available on this platform")
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -48,7 +48,7 @@ func runOpen(cmd *cobra.Command, args []string) error {
 			}
 			url = fmt.Sprintf("%s://%s", protocol, h)
 		} else {
-			url = serviceURL(svc.Protocol, svc.Hostname, alloc.Ports[svcName])
+			url = serviceURL(svc.Protocol, svc.Hostname, alloc.Ports[svcName], false)
 		}
 		if url == "" {
 			continue
@@ -86,7 +86,7 @@ func openService(cmd *cobra.Command, cfg *config.Config, alloc registry.Allocati
 		}
 		url = fmt.Sprintf("%s://%s", svc.Protocol, h)
 	} else {
-		url = serviceURL(svc.Protocol, svc.Hostname, port)
+		url = serviceURL(svc.Protocol, svc.Hostname, port, false)
 	}
 	if url == "" {
 		return fmt.Errorf("Service %q has no protocol set. Add 'protocol: http' to open it in the browser.", name)

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"runtime"
 
+	"github.com/outport-app/outport/internal/certmanager"
 	"github.com/outport-app/outport/internal/config"
 	"github.com/outport-app/outport/internal/registry"
 	"github.com/spf13/cobra"
@@ -33,8 +34,10 @@ func runOpen(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("No ports allocated. Run 'outport apply' first.")
 	}
 
+	useHTTPS := certmanager.IsCAInstalled()
+
 	if len(args) == 1 {
-		return openService(cmd, ctx.Cfg, alloc, args[0])
+		return openService(cmd, ctx.Cfg, alloc, args[0], useHTTPS)
 	}
 
 	opened := 0
@@ -46,9 +49,12 @@ func runOpen(cmd *cobra.Command, args []string) error {
 			if protocol == "" {
 				continue
 			}
+			if useHTTPS {
+				protocol = "https"
+			}
 			url = fmt.Sprintf("%s://%s", protocol, h)
 		} else {
-			url = serviceURL(svc.Protocol, svc.Hostname, alloc.Ports[svcName], false)
+			url = serviceURL(svc.Protocol, svc.Hostname, alloc.Ports[svcName], useHTTPS)
 		}
 		if url == "" {
 			continue
@@ -68,7 +74,7 @@ func runOpen(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func openService(cmd *cobra.Command, cfg *config.Config, alloc registry.Allocation, name string) error {
+func openService(cmd *cobra.Command, cfg *config.Config, alloc registry.Allocation, name string, useHTTPS bool) error {
 	svc, ok := cfg.Services[name]
 	if !ok {
 		return fmt.Errorf("Service %q not found in .outport.yml.", name)
@@ -84,9 +90,13 @@ func openService(cmd *cobra.Command, cfg *config.Config, alloc registry.Allocati
 		if svc.Protocol == "" {
 			return fmt.Errorf("Service %q has no protocol set. Add 'protocol: http' to open it in the browser.", name)
 		}
-		url = fmt.Sprintf("%s://%s", svc.Protocol, h)
+		protocol := svc.Protocol
+		if useHTTPS {
+			protocol = "https"
+		}
+		url = fmt.Sprintf("%s://%s", protocol, h)
 	} else {
-		url = serviceURL(svc.Protocol, svc.Hostname, port, false)
+		url = serviceURL(svc.Protocol, svc.Hostname, port, useHTTPS)
 	}
 	if url == "" {
 		return fmt.Errorf("Service %q has no protocol set. Add 'protocol: http' to open it in the browser.", name)

--- a/cmd/ports.go
+++ b/cmd/ports.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/outport-app/outport/internal/certmanager"
 	"github.com/outport-app/outport/internal/config"
 	"github.com/outport-app/outport/internal/portcheck"
 	"github.com/outport-app/outport/internal/registry"
@@ -37,14 +38,16 @@ func runPorts(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	useHTTPS := certmanager.IsCAInstalled()
+
 	if jsonFlag {
-		return printPortsJSON(cmd, ctx.Cfg, ctx.Instance, alloc)
+		return printPortsJSON(cmd, ctx.Cfg, ctx.Instance, alloc, useHTTPS)
 	}
-	return printPortsStyled(cmd, ctx.Cfg, ctx.Instance, alloc)
+	return printPortsStyled(cmd, ctx.Cfg, ctx.Instance, alloc, useHTTPS)
 }
 
-func printPortsJSON(cmd *cobra.Command, cfg *config.Config, instanceName string, alloc registry.Allocation) error {
-	services := buildServiceMap(cfg, alloc.Ports, alloc.Hostnames)
+func printPortsJSON(cmd *cobra.Command, cfg *config.Config, instanceName string, alloc registry.Allocation, useHTTPS bool) error {
+	services := buildServiceMap(cfg, alloc.Ports, alloc.Hostnames, useHTTPS)
 
 	if portsCheckFlag {
 		portStatus := checkPorts(alloc.Ports)
@@ -60,7 +63,7 @@ func printPortsJSON(cmd *cobra.Command, cfg *config.Config, instanceName string,
 		Services: services,
 	}
 	if portsDerivedFlag {
-		out.Derived = buildDerivedMap(cfg.Derived, resolveDerivedFromAlloc(cfg, alloc.Ports, alloc.Hostnames))
+		out.Derived = buildDerivedMap(cfg.Derived, resolveDerivedFromAlloc(cfg, alloc.Ports, alloc.Hostnames, useHTTPS))
 	}
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
@@ -70,7 +73,7 @@ func printPortsJSON(cmd *cobra.Command, cfg *config.Config, instanceName string,
 	return nil
 }
 
-func printPortsStyled(cmd *cobra.Command, cfg *config.Config, instanceName string, alloc registry.Allocation) error {
+func printPortsStyled(cmd *cobra.Command, cfg *config.Config, instanceName string, alloc registry.Allocation, useHTTPS bool) error {
 	w := cmd.OutOrStdout()
 	printHeader(w, cfg.Name, instanceName)
 
@@ -81,10 +84,10 @@ func printPortsStyled(cmd *cobra.Command, cfg *config.Config, instanceName strin
 		portStatus = checkPorts(alloc.Ports)
 	}
 
-	printFlatServices(w, cfg, serviceNames, alloc.Ports, alloc.Hostnames, portStatus)
+	printFlatServices(w, cfg, serviceNames, alloc.Ports, alloc.Hostnames, portStatus, useHTTPS)
 
 	if portsDerivedFlag {
-		if resolved := resolveDerivedFromAlloc(cfg, alloc.Ports, alloc.Hostnames); len(resolved) > 0 {
+		if resolved := resolveDerivedFromAlloc(cfg, alloc.Ports, alloc.Hostnames, useHTTPS); len(resolved) > 0 {
 			printDerivedValues(w, resolved)
 		}
 	}

--- a/cmd/promote.go
+++ b/cmd/promote.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/outport-app/outport/internal/certmanager"
 	"github.com/outport-app/outport/internal/instance"
 	"github.com/outport-app/outport/internal/ui"
 	"github.com/spf13/cobra"
@@ -38,6 +39,7 @@ func runPromote(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("instance %q not found for project %q", ctx.Instance, cfg.Name)
 	}
 
+	useHTTPS := certmanager.IsCAInstalled()
 	var demotedTo string
 
 	// If a "main" instance exists, demote it
@@ -58,7 +60,7 @@ func runPromote(cmd *cobra.Command, args []string) error {
 		reg.Set(cfg.Name, demotedTo, demotedAlloc)
 
 		// Re-merge .env files for the demoted instance
-		if err := mergeEnvFiles(mainAlloc.ProjectDir, cfg, mainAlloc.Ports, demotedAlloc.Hostnames); err != nil {
+		if err := mergeEnvFiles(mainAlloc.ProjectDir, cfg, mainAlloc.Ports, demotedAlloc.Hostnames, useHTTPS); err != nil {
 			return fmt.Errorf("updating .env files for demoted instance: %w", err)
 		}
 	}
@@ -70,7 +72,7 @@ func runPromote(cmd *cobra.Command, args []string) error {
 	reg.Set(cfg.Name, "main", promotedAlloc)
 
 	// Re-merge .env files for the promoted instance
-	if err := mergeEnvFiles(ctx.Dir, cfg, currentAlloc.Ports, promotedAlloc.Hostnames); err != nil {
+	if err := mergeEnvFiles(ctx.Dir, cfg, currentAlloc.Ports, promotedAlloc.Hostnames, useHTTPS); err != nil {
 		return fmt.Errorf("updating .env files for promoted instance: %w", err)
 	}
 

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/outport-app/outport/internal/certmanager"
 	"github.com/outport-app/outport/internal/config"
 	"github.com/outport-app/outport/internal/dotenv"
 	"github.com/outport-app/outport/internal/instance"
@@ -60,7 +61,8 @@ func runRename(cmd *cobra.Command, args []string) error {
 	reg.Set(cfg.Name, newName, newAlloc)
 
 	// Re-merge .env files with updated hostnames
-	if err := mergeEnvFiles(ctx.Dir, cfg, oldAlloc.Ports, newAlloc.Hostnames); err != nil {
+	useHTTPS := certmanager.IsCAInstalled()
+	if err := mergeEnvFiles(ctx.Dir, cfg, oldAlloc.Ports, newAlloc.Hostnames, useHTTPS); err != nil {
 		return fmt.Errorf("updating .env files: %w", err)
 	}
 
@@ -76,7 +78,7 @@ func runRename(cmd *cobra.Command, args []string) error {
 
 // mergeEnvFiles rebuilds and writes env file vars for an allocation.
 // This is used by rename and promote to update .env files after hostnames change.
-func mergeEnvFiles(dir string, cfg *config.Config, ports map[string]int, hostnames map[string]string) error {
+func mergeEnvFiles(dir string, cfg *config.Config, ports map[string]int, hostnames map[string]string, useHTTPS bool) error {
 	envFileVars := make(map[string]map[string]string)
 
 	for svcName, svc := range cfg.Services {
@@ -90,7 +92,7 @@ func mergeEnvFiles(dir string, cfg *config.Config, ports map[string]int, hostnam
 	}
 
 	// Resolve derived values and add to envFileVars
-	resolvedDerived := resolveDerivedFromAlloc(cfg, ports, hostnames)
+	resolvedDerived := resolveDerivedFromAlloc(cfg, ports, hostnames, useHTTPS)
 	for name, fileValues := range resolvedDerived {
 		for file, value := range fileValues {
 			if envFileVars[file] == nil {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -154,7 +154,7 @@ func runTeardown(cmd *cobra.Command, args []string) error {
 }
 
 func isPortInUse(port int) bool {
-	out, err := exec.Command("lsof", "-i", fmt.Sprintf(":%d", port), "-sTCP:LISTEN", "-t").Output()
+	out, err := exec.Command("lsof", "-iTCP:"+fmt.Sprintf("%d", port), "-sTCP:LISTEN", "-t").Output()
 	if err != nil {
 		return false
 	}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
 
+	"github.com/outport-app/outport/internal/certmanager"
 	"github.com/outport-app/outport/internal/platform"
 	"github.com/outport-app/outport/internal/ui"
 	"github.com/spf13/cobra"
@@ -11,15 +13,15 @@ import (
 
 var setupCmd = &cobra.Command{
 	Use:   "setup",
-	Short: "Install the DNS resolver and daemon",
-	Long:  "Installs the .test DNS resolver and LaunchAgent so that *.test hostnames resolve to your local services.",
+	Short: "Install the DNS resolver, daemon, and local CA for HTTPS",
+	Long:  "Installs the .test DNS resolver, LaunchAgent, and local Certificate Authority so that *.test hostnames resolve to your local services with HTTPS.",
 	RunE:  runSetup,
 }
 
 var teardownCmd = &cobra.Command{
 	Use:   "teardown",
-	Short: "Remove the DNS resolver and daemon",
-	Long:  "Unloads the daemon, removes the LaunchAgent plist, and removes the .test DNS resolver file.",
+	Short: "Remove the DNS resolver, daemon, and certificates",
+	Long:  "Unloads the daemon, removes the LaunchAgent plist, removes the .test DNS resolver file, and removes the CA certificate and cached server certs.",
 	RunE:  runTeardown,
 }
 
@@ -36,66 +38,159 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Check if port 80 is in use
-	if isPort80InUse() {
+	if isPortInUse(80) {
 		return fmt.Errorf("port 80 is already in use — stop the other server first")
 	}
+	if isPortInUse(443) {
+		return fmt.Errorf("port 443 is already in use — stop the other server first")
+	}
 
-	// Find the outport binary
 	outportBin, err := exec.LookPath("outport")
 	if err != nil {
 		return fmt.Errorf("could not find outport binary in PATH: %w", err)
 	}
 
-	fmt.Fprintln(w, "Installing .test domain routing...")
-	fmt.Fprintln(w)
+	caGenerated := false
+	caTrusted := false
+
+	if !jsonFlag {
+		fmt.Fprintln(w, "Installing .test domain routing with HTTPS...")
+		fmt.Fprintln(w)
+	}
 
 	if err := platform.WritePlist(outportBin); err != nil {
 		return err
 	}
 
-	// Resolver file needs sudo — explain why
-	fmt.Fprintln(w, "  Your password is needed to configure .test DNS resolution.")
-	fmt.Fprintln(w)
+	if !jsonFlag {
+		fmt.Fprintln(w, "  Your password is needed to configure .test DNS resolution.")
+		fmt.Fprintln(w)
+	}
 	if err := platform.WriteResolverFile(); err != nil {
 		return err
 	}
+
+	caCertPath, _ := certmanager.CACertPath()
+	caKeyPath, _ := certmanager.CAKeyPath()
+
+	if !certmanager.IsCAInstalled() {
+		if !jsonFlag {
+			fmt.Fprintln(w, "  Generating local Certificate Authority...")
+		}
+		if err := certmanager.GenerateCA(caCertPath, caKeyPath); err != nil {
+			return err
+		}
+		caGenerated = true
+	}
+
+	if !jsonFlag {
+		fmt.Fprintln(w, "  Adding CA to system trust store (you may see a password dialog)...")
+	}
+	if err := platform.TrustCA(caCertPath); err != nil {
+		return fmt.Errorf("CA must be trusted for HTTPS to work: %w", err)
+	}
+	caTrusted = true
 
 	if err := platform.LoadAgent(); err != nil {
 		return err
 	}
 
+	if jsonFlag {
+		return printSetupJSON(cmd, caGenerated, caTrusted)
+	}
+
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, ui.SuccessStyle.Render("Done! *.test domains are now routing to your local services."))
+	fmt.Fprintln(w, ui.SuccessStyle.Render("Done! *.test domains are now routing with HTTPS."))
 	return nil
 }
 
 func runTeardown(cmd *cobra.Command, args []string) error {
 	w := cmd.OutOrStdout()
 
-	// Unload agent (best effort)
-	fmt.Fprintln(w, "Unloading daemon...")
+	caRemoved := false
+	certsCleaned := false
+
+	if !jsonFlag {
+		fmt.Fprintln(w, "Unloading daemon...")
+	}
 	_ = platform.UnloadAgent()
 
-	// Remove plist (best effort)
-	fmt.Fprintln(w, "Removing LaunchAgent...")
+	if !jsonFlag {
+		fmt.Fprintln(w, "Removing LaunchAgent...")
+	}
 	_ = platform.RemovePlist()
 
-	// Remove resolver file (uses sudo)
-	fmt.Fprintln(w, "Removing /etc/resolver/test (sudo may prompt for your password)...")
+	if !jsonFlag {
+		fmt.Fprintln(w, "Removing /etc/resolver/test (sudo may prompt for your password)...")
+	}
 	if err := platform.RemoveResolverFile(); err != nil {
 		return err
 	}
 
-	fmt.Fprintln(w, ui.SuccessStyle.Render("Teardown complete. DNS resolver and daemon removed."))
+	caCertPath, _ := certmanager.CACertPath()
+	caKeyPath, _ := certmanager.CAKeyPath()
+	if certmanager.IsCAInstalled() {
+		if !jsonFlag {
+			fmt.Fprintln(w, "Removing CA from trust store...")
+		}
+		_ = platform.UntrustCA(caCertPath)
+		certmanager.DeleteCA(caCertPath, caKeyPath)
+		caRemoved = true
+	}
+
+	if !jsonFlag {
+		fmt.Fprintln(w, "Removing cached certificates...")
+	}
+	if err := certmanager.DeleteCertCache(); err == nil {
+		certsCleaned = true
+	}
+
+	if jsonFlag {
+		return printTeardownJSON(cmd, caRemoved, certsCleaned)
+	}
+
+	fmt.Fprintln(w, ui.SuccessStyle.Render("Teardown complete. DNS resolver, daemon, and SSL certificates removed."))
 	return nil
 }
 
-// isPort80InUse checks if anything is listening on TCP port 80.
-func isPort80InUse() bool {
-	out, err := exec.Command("lsof", "-i", ":80", "-sTCP:LISTEN", "-t").Output()
+func isPortInUse(port int) bool {
+	out, err := exec.Command("lsof", "-i", fmt.Sprintf(":%d", port), "-sTCP:LISTEN", "-t").Output()
 	if err != nil {
-		return false // lsof exits non-zero when nothing found
+		return false
 	}
 	return len(out) > 0
+}
+
+type setupJSON struct {
+	CAGenerated bool `json:"ca_generated"`
+	CATrusted   bool `json:"ca_trusted"`
+}
+
+func printSetupJSON(cmd *cobra.Command, caGenerated, caTrusted bool) error {
+	data, err := json.MarshalIndent(setupJSON{
+		CAGenerated: caGenerated,
+		CATrusted:   caTrusted,
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return nil
+}
+
+type teardownJSON struct {
+	CARemoved    bool `json:"ca_removed"`
+	CertsCleaned bool `json:"certs_cleaned"`
+}
+
+func printTeardownJSON(cmd *cobra.Command, caRemoved, certsCleaned bool) error {
+	data, err := json.MarshalIndent(teardownJSON{
+		CARemoved:    caRemoved,
+		CertsCleaned: certsCleaned,
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return nil
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/outport-app/outport/internal/certmanager"
 	"github.com/outport-app/outport/internal/config"
 	"github.com/outport-app/outport/internal/portcheck"
 	"github.com/outport-app/outport/internal/registry"
@@ -85,10 +86,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		portStatus = portcheck.CheckAll(allPorts)
 	}
 
+	useHTTPS := certmanager.IsCAInstalled()
+
 	if jsonFlag {
-		return printStatusJSON(cmd, reg, portStatus)
+		return printStatusJSON(cmd, reg, portStatus, useHTTPS)
 	}
-	return printStatusStyled(cmd, reg, portStatus)
+	return printStatusStyled(cmd, reg, portStatus, useHTTPS)
 }
 
 type statusEntryJSON struct {
@@ -99,7 +102,7 @@ type statusEntryJSON struct {
 	Derived    map[string]derivedJSON `json:"derived,omitempty"`
 }
 
-func printStatusJSON(cmd *cobra.Command, reg *registry.Registry, portStatus map[int]bool) error {
+func printStatusJSON(cmd *cobra.Command, reg *registry.Registry, portStatus map[int]bool, useHTTPS bool) error {
 	currentKey := currentProjectKey(reg)
 	var entries []statusEntryJSON
 
@@ -114,7 +117,7 @@ func printStatusJSON(cmd *cobra.Command, reg *registry.Registry, portStatus map[
 			if cfg != nil {
 				if svc, ok := cfg.Services[svcName]; ok {
 					s.Protocol = svc.Protocol
-					s.URL = serviceURL(svc.Protocol, resolvedHostname(svc, alloc.Hostnames, svcName), port)
+					s.URL = serviceURL(svc.Protocol, resolvedHostname(svc, alloc.Hostnames, svcName), port, useHTTPS)
 				}
 			}
 			if portStatus != nil {
@@ -125,7 +128,7 @@ func printStatusJSON(cmd *cobra.Command, reg *registry.Registry, portStatus map[
 
 		var derived map[string]derivedJSON
 		if cfg != nil {
-			derived = buildDerivedMap(cfg.Derived, resolveDerivedFromAlloc(cfg, alloc.Ports, alloc.Hostnames))
+			derived = buildDerivedMap(cfg.Derived, resolveDerivedFromAlloc(cfg, alloc.Ports, alloc.Hostnames, useHTTPS))
 		}
 
 		entries = append(entries, statusEntryJSON{
@@ -147,7 +150,7 @@ func printStatusJSON(cmd *cobra.Command, reg *registry.Registry, portStatus map[
 
 var currentMarker = lipgloss.NewStyle().Foreground(ui.Green).Bold(true)
 
-func printStatusStyled(cmd *cobra.Command, reg *registry.Registry, portStatus map[int]bool) error {
+func printStatusStyled(cmd *cobra.Command, reg *registry.Registry, portStatus map[int]bool, useHTTPS bool) error {
 	w := cmd.OutOrStdout()
 	currentKey := currentProjectKey(reg)
 
@@ -201,7 +204,7 @@ func printStatusStyled(cmd *cobra.Command, reg *registry.Registry, portStatus ma
 			if cfg != nil {
 				if svc, ok := cfg.Services[svcName]; ok {
 					hostname := resolvedHostname(svc, alloc.Hostnames, svcName)
-					if u := serviceURL(svc.Protocol, hostname, port); u != "" {
+					if u := serviceURL(svc.Protocol, hostname, port, useHTTPS); u != "" {
 						extra = "  " + ui.UrlStyle.Render(u)
 					} else if hostname != "" {
 						extra = "  " + ui.HostnameStyle.Render(hostname)
@@ -220,7 +223,7 @@ func printStatusStyled(cmd *cobra.Command, reg *registry.Registry, portStatus ma
 		}
 
 		if cfg != nil {
-			if resolved := resolveDerivedFromAlloc(cfg, alloc.Ports, alloc.Hostnames); len(resolved) > 0 {
+			if resolved := resolveDerivedFromAlloc(cfg, alloc.Ports, alloc.Hostnames, useHTTPS); len(resolved) > 0 {
 				printDerivedValues(w, resolved)
 			}
 		}

--- a/internal/certmanager/ca.go
+++ b/internal/certmanager/ca.go
@@ -1,0 +1,125 @@
+// internal/certmanager/ca.go
+package certmanager
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// GenerateCA creates a new CA certificate and private key at the given paths.
+// If both files already exist, this is a no-op (idempotent).
+// The CA uses EC P-256 with 10-year validity.
+func GenerateCA(certPath, keyPath string) error {
+	if fileExists(certPath) && fileExists(keyPath) {
+		return nil
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generating CA key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("generating serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Outport Dev CA"},
+			CommonName:   "Outport Dev CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return fmt.Errorf("creating CA certificate: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(certPath), 0755); err != nil {
+		return fmt.Errorf("creating cert directory: %w", err)
+	}
+
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		return fmt.Errorf("creating cert file: %w", err)
+	}
+	defer certFile.Close()
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return fmt.Errorf("encoding cert PEM: %w", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return fmt.Errorf("marshaling CA key: %w", err)
+	}
+	keyFile, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("creating key file: %w", err)
+	}
+	defer keyFile.Close()
+	if err := pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		return fmt.Errorf("encoding key PEM: %w", err)
+	}
+
+	return nil
+}
+
+// LoadCA loads the CA certificate and private key from disk.
+func LoadCA(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading CA cert: %w", err)
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, nil, fmt.Errorf("no PEM block in CA cert")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing CA cert: %w", err)
+	}
+
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading CA key: %w", err)
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, nil, fmt.Errorf("no PEM block in CA key")
+	}
+	key, err := x509.ParseECPrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing CA key: %w", err)
+	}
+
+	return cert, key, nil
+}
+
+// DeleteCA removes the CA cert and key files.
+func DeleteCA(certPath, keyPath string) {
+	os.Remove(certPath)
+	os.Remove(keyPath)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/certmanager/ca_test.go
+++ b/internal/certmanager/ca_test.go
@@ -1,0 +1,138 @@
+// internal/certmanager/ca_test.go
+package certmanager
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateCA(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-cert.pem")
+	keyPath := filepath.Join(dir, "ca-key.pem")
+
+	if err := GenerateCA(certPath, keyPath); err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+
+	// Cert file exists and is valid
+	certData, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	block, _ := pem.Decode(certData)
+	if block == nil {
+		t.Fatal("no PEM block in cert")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+
+	if !cert.IsCA {
+		t.Error("cert is not a CA")
+	}
+	if cert.Subject.Organization[0] != "Outport Dev CA" {
+		t.Errorf("org = %q, want %q", cert.Subject.Organization[0], "Outport Dev CA")
+	}
+	if cert.Subject.CommonName != "Outport Dev CA" {
+		t.Errorf("CN = %q, want %q", cert.Subject.CommonName, "Outport Dev CA")
+	}
+	if !cert.MaxPathLenZero {
+		t.Error("MaxPathLenZero should be true")
+	}
+
+	// Key file has 0600 permissions
+	keyInfo, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	if keyInfo.Mode().Perm() != 0600 {
+		t.Errorf("key permissions = %o, want 0600", keyInfo.Mode().Perm())
+	}
+}
+
+func TestGenerateCAIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-cert.pem")
+	keyPath := filepath.Join(dir, "ca-key.pem")
+
+	if err := GenerateCA(certPath, keyPath); err != nil {
+		t.Fatalf("first GenerateCA: %v", err)
+	}
+	certData1, _ := os.ReadFile(certPath)
+
+	if err := GenerateCA(certPath, keyPath); err != nil {
+		t.Fatalf("second GenerateCA: %v", err)
+	}
+	certData2, _ := os.ReadFile(certPath)
+
+	if string(certData1) != string(certData2) {
+		t.Error("second GenerateCA overwrote existing cert")
+	}
+}
+
+func TestLoadCA(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-cert.pem")
+	keyPath := filepath.Join(dir, "ca-key.pem")
+
+	GenerateCA(certPath, keyPath)
+
+	cert, key, err := LoadCA(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("LoadCA: %v", err)
+	}
+	if cert == nil {
+		t.Error("cert is nil")
+	}
+	if key == nil {
+		t.Error("key is nil")
+	}
+	if !cert.IsCA {
+		t.Error("loaded cert is not a CA")
+	}
+}
+
+func TestLoadCAMissingFile(t *testing.T) {
+	_, _, err := LoadCA("/nonexistent/cert.pem", "/nonexistent/key.pem")
+	if err == nil {
+		t.Error("expected error for missing files")
+	}
+}
+
+func TestIsCAInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if IsCAInstalled() {
+		t.Error("expected false when CA does not exist")
+	}
+
+	dataDir := filepath.Join(home, ".local", "share", "outport")
+	os.MkdirAll(dataDir, 0755)
+	GenerateCA(filepath.Join(dataDir, "ca-cert.pem"), filepath.Join(dataDir, "ca-key.pem"))
+
+	if !IsCAInstalled() {
+		t.Error("expected true when CA exists")
+	}
+}
+
+func TestDeleteCA(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-cert.pem")
+	keyPath := filepath.Join(dir, "ca-key.pem")
+
+	GenerateCA(certPath, keyPath)
+	DeleteCA(certPath, keyPath)
+
+	if _, err := os.Stat(certPath); !os.IsNotExist(err) {
+		t.Error("cert file still exists after DeleteCA")
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Error("key file still exists after DeleteCA")
+	}
+}

--- a/internal/certmanager/cert.go
+++ b/internal/certmanager/cert.go
@@ -1,0 +1,151 @@
+// internal/certmanager/cert.go
+package certmanager
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const renewalWindow = 7 * 24 * time.Hour
+
+// GetOrCreateCert returns a TLS certificate for the given hostname.
+// It checks the disk cache first, generates a new cert if missing or expiring.
+func GetOrCreateCert(hostname string, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, cacheDir string) (*tls.Certificate, error) {
+	certPath := filepath.Join(cacheDir, hostname+".pem")
+	keyPath := filepath.Join(cacheDir, hostname+"-key.pem")
+
+	if cert, err := loadCertFromDisk(certPath, keyPath, caCert); err == nil {
+		return cert, nil
+	}
+
+	cert, err := generateServerCert(hostname, caCert, caKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := saveCertToDisk(cacheDir, hostname, cert); err != nil {
+		return nil, err
+	}
+
+	return cert, nil
+}
+
+func loadCertFromDisk(certPath, keyPath string, caCert *x509.Certificate) (*tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, err
+	}
+
+	if time.Until(leaf.NotAfter) < renewalWindow {
+		return nil, fmt.Errorf("cert expiring soon")
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	if _, err := leaf.Verify(x509.VerifyOptions{Roots: pool}); err != nil {
+		return nil, fmt.Errorf("cert not signed by current CA: %w", err)
+	}
+
+	cert.Leaf = leaf
+	return &cert, nil
+}
+
+func generateServerCert(hostname string, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) (*tls.Certificate, error) {
+	return generateServerCertWithExpiry(hostname, caCert, caKey, 365*24*time.Hour)
+}
+
+func generateServerCertWithExpiry(hostname string, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, validity time.Duration) (*tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating server key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generating serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   hostname,
+			Organization: []string{"Outport Dev CA"},
+		},
+		DNSNames:  []string{hostname},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(validity),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+		},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating server certificate: %w", err)
+	}
+
+	return &tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+	}, nil
+}
+
+func saveCertToDisk(cacheDir, hostname string, cert *tls.Certificate) error {
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return fmt.Errorf("creating cert cache dir: %w", err)
+	}
+
+	certPath := filepath.Join(cacheDir, hostname+".pem")
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		return fmt.Errorf("creating cert file: %w", err)
+	}
+	defer certFile.Close()
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]}); err != nil {
+		return fmt.Errorf("encoding cert PEM: %w", err)
+	}
+
+	ecKey, ok := cert.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return fmt.Errorf("private key is not ECDSA")
+	}
+	keyDER, err := x509.MarshalECPrivateKey(ecKey)
+	if err != nil {
+		return fmt.Errorf("marshaling server key: %w", err)
+	}
+	keyFile, err := os.OpenFile(filepath.Join(cacheDir, hostname+"-key.pem"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("creating key file: %w", err)
+	}
+	defer keyFile.Close()
+	if err := pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		return fmt.Errorf("encoding key PEM: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteCertCache removes all cached server certificates.
+func DeleteCertCache() error {
+	dir, err := CertCacheDir()
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(dir)
+}

--- a/internal/certmanager/cert_test.go
+++ b/internal/certmanager/cert_test.go
@@ -1,0 +1,120 @@
+// internal/certmanager/cert_test.go
+package certmanager
+
+import (
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGetOrCreateCert(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath := filepath.Join(dir, "ca-cert.pem")
+	caKeyPath := filepath.Join(dir, "ca-key.pem")
+
+	if err := GenerateCA(caCertPath, caKeyPath); err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+	caCert, caKey, err := LoadCA(caCertPath, caKeyPath)
+	if err != nil {
+		t.Fatalf("LoadCA: %v", err)
+	}
+
+	cacheDir := filepath.Join(dir, "certs")
+
+	cert, err := GetOrCreateCert("myapp.test", caCert, caKey, cacheDir)
+	if err != nil {
+		t.Fatalf("GetOrCreateCert: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+
+	// Check SAN
+	if len(leaf.DNSNames) != 1 || leaf.DNSNames[0] != "myapp.test" {
+		t.Errorf("DNSNames = %v, want [myapp.test]", leaf.DNSNames)
+	}
+
+	// Check signed by our CA
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	if _, err := leaf.Verify(x509.VerifyOptions{Roots: pool}); err != nil {
+		t.Errorf("cert not signed by CA: %v", err)
+	}
+
+	// Check cached to disk
+	certPath := filepath.Join(cacheDir, "myapp.test.pem")
+	if _, err := os.Stat(certPath); err != nil {
+		t.Errorf("cert not cached to disk: %v", err)
+	}
+	keyPath := filepath.Join(cacheDir, "myapp.test-key.pem")
+	keyInfo, err := os.Stat(keyPath)
+	if err != nil {
+		t.Errorf("key not cached to disk: %v", err)
+	} else if keyInfo.Mode().Perm() != 0600 {
+		t.Errorf("key permissions = %o, want 0600", keyInfo.Mode().Perm())
+	}
+}
+
+func TestGetOrCreateCertCached(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath := filepath.Join(dir, "ca-cert.pem")
+	caKeyPath := filepath.Join(dir, "ca-key.pem")
+	GenerateCA(caCertPath, caKeyPath)
+	caCert, caKey, _ := LoadCA(caCertPath, caKeyPath)
+	cacheDir := filepath.Join(dir, "certs")
+
+	cert1, _ := GetOrCreateCert("app.test", caCert, caKey, cacheDir)
+	cert2, _ := GetOrCreateCert("app.test", caCert, caKey, cacheDir)
+
+	if string(cert1.Certificate[0]) != string(cert2.Certificate[0]) {
+		t.Error("second call should return cached cert")
+	}
+}
+
+func TestCertExpiringSoon(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath := filepath.Join(dir, "ca-cert.pem")
+	caKeyPath := filepath.Join(dir, "ca-key.pem")
+	GenerateCA(caCertPath, caKeyPath)
+	caCert, caKey, _ := LoadCA(caCertPath, caKeyPath)
+	cacheDir := filepath.Join(dir, "certs")
+
+	// Generate a cert that expires in 3 days (within 7-day renewal window)
+	cert, err := generateServerCertWithExpiry("soon.test", caCert, caKey, 3*24*time.Hour)
+	if err != nil {
+		t.Fatalf("generateServerCertWithExpiry: %v", err)
+	}
+	if err := saveCertToDisk(cacheDir, "soon.test", cert); err != nil {
+		t.Fatalf("saveCertToDisk: %v", err)
+	}
+
+	// GetOrCreateCert should regenerate it
+	newCert, err := GetOrCreateCert("soon.test", caCert, caKey, cacheDir)
+	if err != nil {
+		t.Fatalf("GetOrCreateCert: %v", err)
+	}
+	newLeaf, _ := x509.ParseCertificate(newCert.Certificate[0])
+	if time.Until(newLeaf.NotAfter) < 30*24*time.Hour {
+		t.Error("cert was not regenerated despite expiring soon")
+	}
+}
+
+func TestDeleteCertCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cacheDir := filepath.Join(home, ".cache", "outport", "certs")
+	os.MkdirAll(cacheDir, 0755)
+	os.WriteFile(filepath.Join(cacheDir, "test.pem"), []byte("test"), 0644)
+
+	if err := DeleteCertCache(); err != nil {
+		t.Fatalf("DeleteCertCache: %v", err)
+	}
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Error("cache dir still exists after DeleteCertCache")
+	}
+}

--- a/internal/certmanager/paths.go
+++ b/internal/certmanager/paths.go
@@ -1,0 +1,54 @@
+// internal/certmanager/paths.go
+package certmanager
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DataDir returns ~/.local/share/outport/ (persistent, machine-specific data).
+func DataDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, ".local", "share", "outport"), nil
+}
+
+// CACertPath returns the path to the CA certificate.
+func CACertPath() (string, error) {
+	dir, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "ca-cert.pem"), nil
+}
+
+// CAKeyPath returns the path to the CA private key.
+func CAKeyPath() (string, error) {
+	dir, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "ca-key.pem"), nil
+}
+
+// CertCacheDir returns ~/.cache/outport/certs/ (regenerable server certs).
+func CertCacheDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("finding home directory: %w", err)
+	}
+	return filepath.Join(home, ".cache", "outport", "certs"), nil
+}
+
+// IsCAInstalled returns true if the CA cert exists on disk.
+func IsCAInstalled() bool {
+	path, err := CACertPath()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(path)
+	return err == nil
+}

--- a/internal/certmanager/store.go
+++ b/internal/certmanager/store.go
@@ -1,0 +1,69 @@
+// internal/certmanager/store.go
+package certmanager
+
+import (
+	"crypto/ecdsa"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"sync"
+)
+
+// CertStore provides thread-safe certificate management with memory and disk caching.
+// Use GetCertificate as a tls.Config.GetCertificate callback.
+type CertStore struct {
+	caCert   *x509.Certificate
+	caKey    *ecdsa.PrivateKey
+	cacheDir string
+
+	mu    sync.RWMutex
+	certs map[string]*tls.Certificate
+}
+
+// NewCertStore creates a CertStore backed by the given CA and cache directory.
+func NewCertStore(caCertPath, caKeyPath, cacheDir string) (*CertStore, error) {
+	caCert, caKey, err := LoadCA(caCertPath, caKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading CA: %w", err)
+	}
+	return &CertStore{
+		caCert:   caCert,
+		caKey:    caKey,
+		cacheDir: cacheDir,
+		certs:    make(map[string]*tls.Certificate),
+	}, nil
+}
+
+// GetCertificate implements tls.Config.GetCertificate.
+// Checks memory cache, then disk cache, then generates a new cert.
+func (s *CertStore) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	hostname := hello.ServerName
+
+	// Check memory cache (read lock)
+	s.mu.RLock()
+	cert, ok := s.certs[hostname]
+	s.mu.RUnlock()
+	if ok {
+		return cert, nil
+	}
+
+	// Acquire write lock with double-check
+	s.mu.Lock()
+	cert, ok = s.certs[hostname]
+	if ok {
+		s.mu.Unlock()
+		return cert, nil
+	}
+
+	// Get or create (checks disk, generates if needed)
+	cert, err := GetOrCreateCert(hostname, s.caCert, s.caKey, s.cacheDir)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("getting cert for %s: %w", hostname, err)
+	}
+
+	s.certs[hostname] = cert
+	s.mu.Unlock()
+
+	return cert, nil
+}

--- a/internal/certmanager/store_test.go
+++ b/internal/certmanager/store_test.go
@@ -1,0 +1,67 @@
+// internal/certmanager/store_test.go
+package certmanager
+
+import (
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCertStoreGetCertificate(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath := filepath.Join(dir, "ca-cert.pem")
+	caKeyPath := filepath.Join(dir, "ca-key.pem")
+	GenerateCA(caCertPath, caKeyPath)
+	cacheDir := filepath.Join(dir, "certs")
+
+	store, err := NewCertStore(caCertPath, caKeyPath, cacheDir)
+	if err != nil {
+		t.Fatalf("NewCertStore: %v", err)
+	}
+
+	hello := &tls.ClientHelloInfo{ServerName: "myapp.test"}
+	cert, err := store.GetCertificate(hello)
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("cert is nil")
+	}
+
+	// Second call should return from memory cache (same pointer)
+	cert2, err := store.GetCertificate(hello)
+	if err != nil {
+		t.Fatalf("GetCertificate (cached): %v", err)
+	}
+	if cert != cert2 {
+		t.Error("expected same pointer from memory cache")
+	}
+}
+
+func TestCertStoreLoadFromDiskCache(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath := filepath.Join(dir, "ca-cert.pem")
+	caKeyPath := filepath.Join(dir, "ca-key.pem")
+	GenerateCA(caCertPath, caKeyPath)
+	cacheDir := filepath.Join(dir, "certs")
+
+	// First store generates and caches to disk
+	store1, _ := NewCertStore(caCertPath, caKeyPath, cacheDir)
+	hello := &tls.ClientHelloInfo{ServerName: "app.test"}
+	store1.GetCertificate(hello)
+
+	// Second store (fresh memory, same disk cache) should load from disk
+	store2, _ := NewCertStore(caCertPath, caKeyPath, cacheDir)
+	cert, err := store2.GetCertificate(hello)
+	if err != nil {
+		t.Fatalf("GetCertificate from disk: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("cert is nil from disk")
+	}
+
+	if _, err := os.Stat(filepath.Join(cacheDir, "app.test.pem")); err != nil {
+		t.Errorf("cert not on disk: %v", err)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,18 +12,21 @@ import (
 
 // DaemonConfig holds configuration for the daemon process.
 type DaemonConfig struct {
-	DNSAddr      string       // UDP address for DNS (e.g., "127.0.0.1:15353")
-	ProxyAddr    string       // TCP address for HTTP proxy (e.g., ":80")
-	RegistryPath string       // Path to registry.json
-	Listener     net.Listener // Optional pre-bound listener (for launchd socket activation)
+	DNSAddr       string       // UDP address for DNS (e.g., "127.0.0.1:15353")
+	ProxyAddr     string       // TCP address for HTTP proxy (e.g., ":80")
+	HTTPListener  net.Listener // Pre-bound HTTP listener (launchd socket activation)
+	HTTPSListener net.Listener // Pre-bound HTTPS listener (launchd socket activation)
+	TLSConfig     *tls.Config  // TLS config with GetCertificate callback (nil = no HTTPS)
+	RegistryPath  string       // Path to registry.json
 }
 
 // Daemon coordinates the DNS server, HTTP proxy, and route watcher.
 type Daemon struct {
-	cfg    *DaemonConfig
-	routes *RouteTable
-	dns    *dns.Server
-	proxy  *http.Server
+	cfg      *DaemonConfig
+	routes   *RouteTable
+	dns      *dns.Server
+	proxy    *http.Server
+	tlsProxy *http.Server
 }
 
 // New creates a new Daemon instance.
@@ -32,22 +36,48 @@ func New(cfg *DaemonConfig) (*Daemon, error) {
 	routes.OnUpdate = proxyHandler.ClearCache
 
 	dnsSrv := NewDNSServer(cfg.DNSAddr)
-	httpSrv := &http.Server{
-		Addr:    cfg.ProxyAddr,
-		Handler: proxyHandler,
+
+	var httpHandler http.Handler
+	if cfg.TLSConfig != nil {
+		httpHandler = http.HandlerFunc(redirectToHTTPS)
+	} else {
+		httpHandler = proxyHandler
 	}
 
-	return &Daemon{
+	httpSrv := &http.Server{
+		Addr:    cfg.ProxyAddr,
+		Handler: httpHandler,
+	}
+
+	d := &Daemon{
 		cfg:    cfg,
 		routes: routes,
 		dns:    dnsSrv,
 		proxy:  httpSrv,
-	}, nil
+	}
+
+	if cfg.TLSConfig != nil {
+		d.tlsProxy = &http.Server{
+			Handler:   proxyHandler,
+			TLSConfig: cfg.TLSConfig,
+		}
+	}
+
+	return d, nil
+}
+
+func redirectToHTTPS(w http.ResponseWriter, r *http.Request) {
+	target := "https://" + r.Host + r.RequestURI
+	http.Redirect(w, r, target, http.StatusTemporaryRedirect)
 }
 
 // Run starts the daemon and blocks until the context is cancelled.
 func (d *Daemon) Run(ctx context.Context) error {
-	errCh := make(chan error, 3)
+	serverCount := 3
+	if d.tlsProxy != nil {
+		serverCount = 4
+	}
+	errCh := make(chan error, serverCount)
 
 	// Start route watcher
 	go func() {
@@ -62,8 +92,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Start HTTP proxy
 	go func() {
 		var err error
-		if d.cfg.Listener != nil {
-			err = d.proxy.Serve(d.cfg.Listener)
+		if d.cfg.HTTPListener != nil {
+			err = d.proxy.Serve(d.cfg.HTTPListener)
 		} else {
 			err = d.proxy.ListenAndServe()
 		}
@@ -73,15 +103,37 @@ func (d *Daemon) Run(ctx context.Context) error {
 		errCh <- err
 	}()
 
+	// Start HTTPS proxy if TLS is configured
+	if d.tlsProxy != nil {
+		go func() {
+			var err error
+			if d.cfg.HTTPSListener != nil {
+				err = d.tlsProxy.ServeTLS(d.cfg.HTTPSListener, "", "")
+			} else {
+				err = d.tlsProxy.ListenAndServeTLS("", "")
+			}
+			if err == http.ErrServerClosed {
+				err = nil
+			}
+			errCh <- err
+		}()
+	}
+
 	// Wait for context cancellation or error
 	select {
 	case <-ctx.Done():
 		d.dns.Shutdown()
 		d.proxy.Close()
+		if d.tlsProxy != nil {
+			d.tlsProxy.Close()
+		}
 		return nil
 	case err := <-errCh:
 		d.dns.Shutdown()
 		d.proxy.Close()
+		if d.tlsProxy != nil {
+			d.tlsProxy.Close()
+		}
 		return fmt.Errorf("daemon component failed: %w", err)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,13 +2,19 @@ package daemon
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/outport-app/outport/internal/certmanager"
 	"github.com/outport-app/outport/internal/registry"
 )
 
@@ -85,4 +91,201 @@ func TestDaemonStartAndShutdown(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for daemon shutdown")
 	}
+}
+
+func TestDaemonHTTPS(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+	caCertPath := filepath.Join(dir, "ca-cert.pem")
+	caKeyPath := filepath.Join(dir, "ca-key.pem")
+	cacheDir := filepath.Join(dir, "certs")
+
+	if err := certmanager.GenerateCA(caCertPath, caKeyPath); err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
+	store, err := certmanager.NewCertStore(caCertPath, caKeyPath, cacheDir)
+	if err != nil {
+		t.Fatalf("NewCertStore: %v", err)
+	}
+
+	// Start a backend HTTP server
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello from backend"))
+	}))
+	defer backend.Close()
+	backendPort := backend.Listener.Addr().(*net.TCPAddr).Port
+
+	// Write registry
+	reg := &registry.Registry{Projects: make(map[string]registry.Allocation)}
+	reg.Set("app1", "main", registry.Allocation{
+		ProjectDir: "/src/app1",
+		Ports:      map[string]int{"web": backendPort},
+		Hostnames:  map[string]string{"web": "app1.test"},
+		Protocols:  map[string]string{"web": "https"},
+	})
+	data, _ := json.MarshalIndent(reg, "", "  ")
+	os.WriteFile(regPath, data, 0644)
+
+	// Bind listeners
+	httpLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	httpsLn, _ := net.Listen("tcp", "127.0.0.1:0")
+
+	dnsPC, _ := net.ListenPacket("udp", "127.0.0.1:0")
+	dnsAddr := dnsPC.LocalAddr().String()
+	dnsPC.Close()
+
+	d, err := New(&DaemonConfig{
+		DNSAddr:       dnsAddr,
+		ProxyAddr:     httpLn.Addr().String(),
+		HTTPListener:  httpLn,
+		HTTPSListener: httpsLn,
+		TLSConfig:     &tls.Config{GetCertificate: store.GetCertificate},
+		RegistryPath:  regPath,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.Run(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	// Load CA into client trust pool
+	caCertPEM, _ := os.ReadFile(caCertPath)
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caCertPEM)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    pool,
+				ServerName: "app1.test",
+			},
+		},
+	}
+
+	// Must set Host header so proxy can route by hostname
+	req, _ := http.NewRequest("GET", "https://"+httpsLn.Addr().String()+"/", nil)
+	req.Host = "app1.test"
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "hello from backend" {
+		t.Errorf("body = %q, want %q", body, "hello from backend")
+	}
+
+	cancel()
+}
+
+func TestDaemonHTTPRedirect(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+	caCertPath := filepath.Join(dir, "ca-cert.pem")
+	caKeyPath := filepath.Join(dir, "ca-key.pem")
+	cacheDir := filepath.Join(dir, "certs")
+
+	certmanager.GenerateCA(caCertPath, caKeyPath)
+	store, _ := certmanager.NewCertStore(caCertPath, caKeyPath, cacheDir)
+
+	reg := &registry.Registry{Projects: make(map[string]registry.Allocation)}
+	data, _ := json.MarshalIndent(reg, "", "  ")
+	os.WriteFile(regPath, data, 0644)
+
+	httpLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	httpsLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	dnsPC, _ := net.ListenPacket("udp", "127.0.0.1:0")
+	dnsAddr := dnsPC.LocalAddr().String()
+	dnsPC.Close()
+
+	d, _ := New(&DaemonConfig{
+		DNSAddr:       dnsAddr,
+		ProxyAddr:     httpLn.Addr().String(),
+		HTTPListener:  httpLn,
+		HTTPSListener: httpsLn,
+		TLSConfig:     &tls.Config{GetCertificate: store.GetCertificate},
+		RegistryPath:  regPath,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.Run(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	req, _ := http.NewRequest("GET", "http://"+httpLn.Addr().String()+"/some/path", nil)
+	req.Host = "myapp.test"
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusTemporaryRedirect)
+	}
+	location := resp.Header.Get("Location")
+	if location != "https://myapp.test/some/path" {
+		t.Errorf("Location = %q, want %q", location, "https://myapp.test/some/path")
+	}
+
+	cancel()
+}
+
+func TestDaemonHTTPProxyWithoutTLS(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("plain http"))
+	}))
+	defer backend.Close()
+	backendPort := backend.Listener.Addr().(*net.TCPAddr).Port
+
+	reg := &registry.Registry{Projects: make(map[string]registry.Allocation)}
+	reg.Set("app1", "main", registry.Allocation{
+		ProjectDir: "/src/app1",
+		Ports:      map[string]int{"web": backendPort},
+		Hostnames:  map[string]string{"web": "app1.test"},
+		Protocols:  map[string]string{"web": "http"},
+	})
+	data, _ := json.MarshalIndent(reg, "", "  ")
+	os.WriteFile(regPath, data, 0644)
+
+	httpLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	dnsPC, _ := net.ListenPacket("udp", "127.0.0.1:0")
+	dnsAddr := dnsPC.LocalAddr().String()
+	dnsPC.Close()
+
+	// No TLSConfig — should proxy, not redirect
+	d, _ := New(&DaemonConfig{
+		DNSAddr:      dnsAddr,
+		ProxyAddr:    httpLn.Addr().String(),
+		HTTPListener: httpLn,
+		RegistryPath: regPath,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.Run(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	req, _ := http.NewRequest("GET", "http://"+httpLn.Addr().String()+"/", nil)
+	req.Host = "app1.test"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "plain http" {
+		t.Errorf("body = %q, want %q", body, "plain http")
+	}
+
+	cancel()
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -50,7 +50,7 @@ func TestDaemonStartAndShutdown(t *testing.T) {
 		DNSAddr:      dnsAddr,
 		ProxyAddr:    ln.Addr().String(),
 		RegistryPath: regPath,
-		Listener:     ln,
+		HTTPListener: ln,
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/platform/darwin.go
+++ b/internal/platform/darwin.go
@@ -114,12 +114,19 @@ func GeneratePlist(outportBinary string) string {
     <true/>
     <key>Sockets</key>
     <dict>
-        <key>Socket</key>
+        <key>HTTPSocket</key>
         <dict>
             <key>SockNodeName</key>
             <string>127.0.0.1</string>
             <key>SockServiceName</key>
             <string>80</string>
+        </dict>
+        <key>HTTPSSocket</key>
+        <dict>
+            <key>SockNodeName</key>
+            <string>127.0.0.1</string>
+            <key>SockServiceName</key>
+            <string>443</string>
         </dict>
     </dict>
     <key>StandardOutPath</key>

--- a/internal/platform/darwin.go
+++ b/internal/platform/darwin.go
@@ -166,3 +166,29 @@ func UnloadAgent() error {
 	}
 	return nil
 }
+
+// TrustCA adds the CA certificate to the macOS login keychain trust store.
+// This triggers a macOS GUI dialog prompting for the login keychain password.
+func TrustCA(certPath string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("finding home directory: %w", err)
+	}
+	keychainPath := filepath.Join(home, "Library", "Keychains", "login.keychain-db")
+	cmd := exec.Command("security", "add-trusted-cert", "-r", "trustRoot", "-k", keychainPath, certPath)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("adding CA to trust store (did you cancel the dialog?): %w", err)
+	}
+	return nil
+}
+
+// UntrustCA removes the CA certificate from the macOS trust store.
+func UntrustCA(certPath string) error {
+	cmd := exec.Command("security", "remove-trusted-cert", certPath)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("removing CA from trust store: %w", err)
+	}
+	return nil
+}

--- a/internal/platform/darwin_test.go
+++ b/internal/platform/darwin_test.go
@@ -53,6 +53,22 @@ func TestIsSetup(t *testing.T) {
 	_ = IsSetup()
 }
 
+func TestGeneratePlistDualSockets(t *testing.T) {
+	plist := GeneratePlist("/usr/local/bin/outport")
+	if !strings.Contains(plist, "<key>HTTPSocket</key>") {
+		t.Error("plist missing HTTPSocket key")
+	}
+	if !strings.Contains(plist, "<key>HTTPSSocket</key>") {
+		t.Error("plist missing HTTPSSocket key")
+	}
+	if !strings.Contains(plist, "<string>443</string>") {
+		t.Error("plist missing port 443")
+	}
+	if strings.Contains(plist, `<key>Socket</key>`) {
+		t.Error("plist still has old Socket key")
+	}
+}
+
 func TestPlistPath(t *testing.T) {
 	path := plistPath()
 	if path == "" {

--- a/internal/platform/other.go
+++ b/internal/platform/other.go
@@ -16,3 +16,5 @@ func RemovePlist() error                { return errUnsupported }
 func LoadAgent() error                  { return errUnsupported }
 func UnloadAgent() error                { return errUnsupported }
 func GeneratePlist(_ string) string     { return "" }
+func TrustCA(_ string) error            { return errUnsupported }
+func UntrustCA(_ string) error          { return errUnsupported }

--- a/internal/registry/path.go
+++ b/internal/registry/path.go
@@ -11,5 +11,5 @@ func DefaultPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("finding home directory: %w", err)
 	}
-	return filepath.Join(home, ".config", "outport", "registry.json"), nil
+	return filepath.Join(home, ".local", "share", "outport", "registry.json"), nil
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,8 +1,8 @@
 package registry
 
 import (
+	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -186,11 +186,16 @@ func TestFindByProject(t *testing.T) {
 }
 
 func TestDefaultPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
 	path, err := DefaultPath()
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("DefaultPath: %v", err)
 	}
-	if !strings.HasSuffix(path, ".config/outport/registry.json") {
-		t.Errorf("path = %q, want suffix .config/outport/registry.json", path)
+	expected := filepath.Join(home, ".local", "share", "outport", "registry.json")
+	if path != expected {
+		t.Errorf("DefaultPath() = %q, want %q", path, expected)
 	}
 }


### PR DESCRIPTION
## Summary

- Browser-trusted HTTPS for all `.test` hostnames via a local Certificate Authority
- Zero per-project configuration — `outport setup` generates a CA and trusts it, then every `.test` hostname automatically gets HTTPS
- New `internal/certmanager` package: CA generation (EC P-256, 10-year), on-demand server certs via TLS SNI callback, memory + disk caching with 7-day expiry renewal
- Daemon gains dual listeners: port 80 (HTTP→HTTPS 307 redirect) and port 443 (TLS proxy)
- LaunchAgent plist updated for dual socket activation (`HTTPSocket`/`HTTPSSocket`)
- `outport apply` and `outport open` produce `https://` URLs when CA is installed
- `outport setup`/`teardown` manage CA lifecycle with `--json` output
- Registry moved to `~/.local/share/outport/` (XDG compliance), cert cache at `~/.cache/outport/certs/`
- 175 tests (18 new), all passing

## Test plan

- [x] `just test` passes (175 tests)
- [x] `just build` succeeds
- [x] `outport teardown` + clean data + `outport setup` works end-to-end
- [x] `outport apply` shows `https://` URLs
- [x] Browser loads `https://myapp.test` with trusted certificate, no warnings

Closes #14