### PR TITLE
Add CI: lint + tests on every push/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: stable
 
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
 
   test:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,29 @@
-run:
-  timeout: 5m
+version: "2"
+
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - os.Remove
+    staticcheck:
+      checks:
+        - "all"
+        - "-ST1000"    # package comments
+        - "-ST1003"    # Go initialisms (UrlStyle vs URLStyle)
+        - "-ST1005"    # error strings ending with punctuation (user-facing messages)
+        - "-QF*"       # quickfix suggestions, not errors
+
+  exclusions:
+    rules:
+      - linters: [errcheck]
+        path: cmd/
+        text: "lipgloss\\."
+      - linters: [errcheck]
+        path: internal/
+        text: "(Close|Shutdown)"
 
 issues:
   max-issues-per-linter: 0

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 # Install dev tools (gotestsum, golangci-lint, goreleaser)
 setup:
     go install gotest.tools/gotestsum@latest
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
     go install github.com/goreleaser/goreleaser/v2@latest
     npm install
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs on pushes to master and all PRs
- **Lint job**: uses `golangci/golangci-lint-action@v8` (caches the linter binary)
- **Test job**: runs `go test ./...`
- Lint and test run as separate jobs so they execute in parallel

Closes #43

## Test plan

- [ ] CI runs on this PR itself (meta-test)
- [ ] Both lint and test jobs pass green