### PR TITLE
Add outport doctor diagnostic command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 .superpowers/
+.worktrees/
 node_modules/
 docs/.vitepress/dist/
 docs/.vitepress/cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Entry point: `main.go` → `cmd.Execute()` (Cobra CLI).
 - **instance** — Resolves instance names for projects. First instance of a project is "main". Additional instances get random 4-character consonant codes (e.g., "bxcf"). Looks up the registry by directory to find existing instances. Provides name validation (lowercase alphanumeric + hyphens).
 - **daemon** — Long-running process providing DNS server (port 15353, resolves `*.test` to 127.0.0.1), HTTP reverse proxy (port 80, 307 redirect to HTTPS when CA exists), and TLS reverse proxy (port 443, SNI-based cert selection). Watches the registry file for changes and rebuilds the route table automatically. Supports WebSocket proxying.
 - **platform** — macOS-specific integration for the daemon. Manages the LaunchAgent plist (`~/Library/LaunchAgents/`) and `/etc/resolver/test` file for `.test` domain resolution. Provides setup/uninstall/start/stop/restart operations and CA trust/untrust via macOS `security` CLI.
+- **doctor** — Diagnostic checks for the `outport doctor` command. `Check`, `Result`, and `Runner` types. `SystemChecks()` returns checks for DNS, daemon, CA, registry, and cloudflared. `ProjectChecks()` returns checks for config validation, registry lookup, and port availability. Each check returns pass/warn/fail with a fix suggestion.
 - **dotenv** — Writes allocated ports and derived values into a fenced block (`# --- begin outport.dev ---` / `# --- end outport.dev ---`) at the bottom of `.env` files. User content outside the block is preserved. Managed vars in the user section are removed and relocated into the block. Also provides `RemoveBlock()` for cleanup.
 - **tunnel** — Tunnel provider abstraction and concurrent manager. Provider interface allows swapping tunnel backends (Cloudflare, etc.) without changing command code. Manager starts/stops multiple tunnels with all-or-nothing semantics and configurable timeout.
 - **tunnel/cloudflare** — Cloudflare quick tunnel provider. Shells out to `cloudflared tunnel --url`, parses tunnel URL from stderr output.
@@ -52,6 +53,7 @@ Project commands (top-level):
 - **share** — Tunnel HTTP services to public URLs via Cloudflare quick tunnels. Shares all HTTP services by default, or specify service names. Requires `cloudflared` binary. Rewrites `.env` files so `${service.url}` derived values resolve to tunnel URLs (`${service.url:direct}` stays localhost). Reverts `.env` on exit. Blocks until Ctrl+C.
 - **rename** — Rename an instance of the current project. Updates hostnames and re-merges `.env` files.
 - **promote** — Promote the current instance to "main". Demotes the existing main instance to a generated code name. Updates hostnames for both instances.
+- **doctor** — Diagnostic command that checks the health of all Outport infrastructure: DNS resolver, LaunchAgent daemon, CA certificates, registry, and project config (when `.outport.yml` is found). Reports pass/warn/fail for each check with actionable fix suggestions. Read-only — never modifies system state.
 
 System commands (under `outport system`):
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ outport share                  Tunnel HTTP services to public URLs
 outport share web              Tunnel a specific service
 outport rename <old> <new>     Rename an instance
 outport promote                Promote the current instance to main
+outport doctor                 Check the health of the outport system
 ```
 
 ### System Commands

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1871,3 +1871,139 @@ func TestPrintShareJSON_IncludesDerivedValues(t *testing.T) {
 		t.Errorf("API_URL derived value = %q, want tunnel-based URL", d.Value)
 	}
 }
+
+// --- doctor ---
+
+func TestDoctor_JSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	jsonFlag = false
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"doctor", "--json"})
+
+	// Doctor returns ErrSilent when checks fail (expected in test env
+	// where system infrastructure is not installed).
+	err := rootCmd.Execute()
+
+	output := buf.String()
+	var result struct {
+		Results []struct {
+			Name     string `json:"name"`
+			Category string `json:"category"`
+			Status   string `json:"status"`
+			Message  string `json:"message"`
+			Fix      string `json:"fix,omitempty"`
+		} `json:"results"`
+		Passed bool `json:"passed"`
+	}
+	if jsonErr := json.Unmarshal([]byte(output), &result); jsonErr != nil {
+		t.Fatalf("invalid JSON output: %v\nOutput: %s", jsonErr, output)
+	}
+
+	// Should have system checks (at least resolver, plist, agent, CA, registry, cloudflared)
+	if len(result.Results) < 10 {
+		t.Errorf("expected at least 10 system checks, got %d", len(result.Results))
+	}
+
+	// Each result should have required fields
+	for i, r := range result.Results {
+		if r.Name == "" {
+			t.Errorf("result[%d] missing name", i)
+		}
+		if r.Category == "" {
+			t.Errorf("result[%d] %q missing category", i, r.Name)
+		}
+		if r.Status != "pass" && r.Status != "warn" && r.Status != "fail" {
+			t.Errorf("result[%d] %q has invalid status %q", i, r.Name, r.Status)
+		}
+		if r.Message == "" {
+			t.Errorf("result[%d] %q missing message", i, r.Name)
+		}
+	}
+
+	// In test env without system setup, should have failures
+	if result.Passed {
+		t.Error("expected passed=false in test environment without system setup")
+	}
+	if err == nil {
+		t.Error("expected ErrSilent when checks fail")
+	}
+}
+
+func TestDoctor_Styled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	jsonFlag = false
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"doctor"})
+
+	_ = rootCmd.Execute()
+
+	output := buf.String()
+
+	// Should contain check indicators
+	if !strings.Contains(output, "✓") && !strings.Contains(output, "✗") && !strings.Contains(output, "!") {
+		t.Error("styled output should contain check indicators (✓, ✗, or !)")
+	}
+
+	// Should contain a summary line
+	if !strings.Contains(output, "checks") && !strings.Contains(output, "passed") {
+		t.Error("styled output should contain a summary line")
+	}
+}
+
+func TestDoctor_WithProject(t *testing.T) {
+	setupProject(t, testConfig)
+	executeCmd(t, "up", "--json")
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"doctor", "--json"})
+
+	_ = rootCmd.Execute()
+
+	output := buf.String()
+	var result struct {
+		Results []struct {
+			Name     string `json:"name"`
+			Category string `json:"category"`
+			Status   string `json:"status"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\nOutput: %s", err, output)
+	}
+
+	// Should include project checks (category starts with "Project")
+	hasProjectCheck := false
+	for _, r := range result.Results {
+		if strings.HasPrefix(r.Category, "Project") {
+			hasProjectCheck = true
+			break
+		}
+	}
+	if !hasProjectCheck {
+		t.Error("expected project checks when .outport.yml exists and project is registered")
+	}
+
+	// Should have config valid check
+	hasConfigCheck := false
+	for _, r := range result.Results {
+		if strings.Contains(r.Name, ".outport.yml") {
+			hasConfigCheck = true
+			if r.Status != "pass" {
+				t.Errorf(".outport.yml check should pass, got %q", r.Status)
+			}
+		}
+	}
+	if !hasConfigCheck {
+		t.Error("expected .outport.yml validity check in project checks")
+	}
+}

--- a/cmd/cmdutil.go
+++ b/cmd/cmdutil.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ErrSilent is returned when a command wants to set exit code 1
+// without printing an error message to stderr.
+var ErrSilent = errors.New("")
+
 // writeJSON marshals v as indented JSON and writes it to the command's stdout.
 func writeJSON(cmd *cobra.Command, v any) error {
 	data, err := json.MarshalIndent(v, "", "  ")

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -89,12 +88,7 @@ func printDoctorJSON(cmd *cobra.Command, results []doctor.Result) error {
 			Fix:      r.Fix,
 		})
 	}
-	data, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(cmd.OutOrStdout(), string(data))
-	return nil
+	return writeJSON(cmd, out)
 }
 
 // Styled output

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"charm.land/lipgloss/v2"
+	"github.com/outport-app/outport/internal/config"
+	"github.com/outport-app/outport/internal/doctor"
+	"github.com/outport-app/outport/internal/registry"
+	"github.com/outport-app/outport/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var doctorCmd = &cobra.Command{
+	Use:     "doctor",
+	Short:   "Check the health of the outport system",
+	Long:    "Runs diagnostic checks on DNS, daemon, certificates, registry, and project configuration. Reports pass/warn/fail for each check with actionable fix suggestions.",
+	GroupID: "project",
+	Args:    NoArgs,
+	RunE:    runDoctor,
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	r := &doctor.Runner{}
+
+	// System checks (always)
+	for _, c := range doctor.SystemChecks() {
+		r.Add(c)
+	}
+
+	// Project checks (when .outport.yml found)
+	cwd, err := os.Getwd()
+	if err == nil {
+		if dir, findErr := config.FindDir(cwd); findErr == nil {
+			regPath, _ := registry.DefaultPath()
+			cfg, configErr := config.Load(dir)
+			for _, c := range doctor.ProjectChecks(dir, cfg, configErr, regPath) {
+				r.Add(c)
+			}
+		}
+	}
+
+	results := r.Run()
+
+	if jsonFlag {
+		return printDoctorJSON(cmd, results)
+	}
+
+	printDoctorStyled(cmd.OutOrStdout(), results)
+
+	if doctor.HasFailures(results) {
+		return ErrSilent
+	}
+	return nil
+}
+
+// JSON output
+
+type resultJSON struct {
+	Name     string `json:"name"`
+	Category string `json:"category"`
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	Fix      string `json:"fix,omitempty"`
+}
+
+type doctorJSON struct {
+	Results []resultJSON `json:"results"`
+	Passed  bool         `json:"passed"`
+}
+
+func printDoctorJSON(cmd *cobra.Command, results []doctor.Result) error {
+	out := doctorJSON{
+		Passed: !doctor.HasFailures(results),
+	}
+	for _, r := range results {
+		out.Results = append(out.Results, resultJSON{
+			Name:     r.Name,
+			Category: r.Category,
+			Status:   r.Status.String(),
+			Message:  r.Message,
+			Fix:      r.Fix,
+		})
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return nil
+}
+
+// Styled output
+
+func printDoctorStyled(w io.Writer, results []doctor.Result) {
+	currentCategory := ""
+	for _, r := range results {
+		if r.Category != currentCategory {
+			if currentCategory != "" {
+				lipgloss.Fprintln(w) // blank line between categories
+			}
+			lipgloss.Fprintln(w, ui.ProjectStyle.Render(r.Category))
+			currentCategory = r.Category
+		}
+
+		var icon string
+		switch r.Status {
+		case doctor.Pass:
+			icon = lipgloss.NewStyle().Foreground(ui.Green).Render("✓")
+		case doctor.Warn:
+			icon = lipgloss.NewStyle().Foreground(ui.Yellow).Render("!")
+		case doctor.Fail:
+			icon = lipgloss.NewStyle().Foreground(ui.Red).Render("✗")
+		}
+
+		lipgloss.Fprintln(w, fmt.Sprintf("  %s %s", icon, r.Message))
+
+		if r.Fix != "" {
+			lipgloss.Fprintln(w, fmt.Sprintf("    %s %s", ui.Arrow, ui.DimStyle.Render(r.Fix)))
+		}
+	}
+
+	lipgloss.Fprintln(w)
+	if doctor.HasFailures(results) {
+		lipgloss.Fprintln(w, lipgloss.NewStyle().Foreground(ui.Red).Render("Some checks failed. See suggestions above."))
+	} else {
+		lipgloss.Fprintln(w, ui.SuccessStyle.Render("All checks passed."))
+	}
+}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -49,10 +49,12 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	results := r.Run()
 
 	if jsonFlag {
-		return printDoctorJSON(cmd, results)
+		if err := printDoctorJSON(cmd, results); err != nil {
+			return err
+		}
+	} else {
+		printDoctorStyled(cmd.OutOrStdout(), results)
 	}
-
-	printDoctorStyled(cmd.OutOrStdout(), results)
 
 	if doctor.HasFailures(results) {
 		return ErrSilent

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -119,6 +119,26 @@ Promotes the current worktree instance to "main", demoting the existing main ins
 |------|-------------|
 | `--json` | Output results as JSON |
 
+### `outport doctor`
+
+Check the health of the outport system.
+
+```bash
+outport doctor
+```
+
+Runs diagnostic checks on all Outport infrastructure and project configuration. Reports pass/warn/fail for each check with actionable fix suggestions. Checks include:
+
+**System checks** (always run): DNS resolver file, resolver content, LaunchAgent plist, plist binary validity, daemon agent loaded, DNS resolution, HTTP proxy (port 80), HTTPS proxy (port 443), CA certificate and key existence, CA expiry, CA trust, registry validity, cloudflared availability.
+
+**Project checks** (when `.outport.yml` found): config file validation, project registration in the registry, allocated port availability.
+
+Exit code 0 if all checks pass or warn. Exit code 1 if any check fails.
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output results as JSON (includes `results` array and `passed` boolean) |
+
 ## System Commands
 
 These commands manage machine-wide infrastructure: the `.test` domain DNS resolver, HTTPS reverse proxy, local Certificate Authority, and registry maintenance.

--- a/docs/superpowers/plans/2026-03-18-outport-doctor.md
+++ b/docs/superpowers/plans/2026-03-18-outport-doctor.md
@@ -1,0 +1,1269 @@
+# `outport doctor` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a top-level `outport doctor` diagnostic command that checks the health of all Outport infrastructure and reports pass/warn/fail with actionable fix suggestions.
+
+**Architecture:** New `internal/doctor/` package with `Check`, `Result`, `Runner` types. System checks always run; project checks run when `.outport.yml` is found. A few exports are added to `internal/platform/` and `internal/certmanager/` so doctor can reuse existing logic without duplication.
+
+**Tech Stack:** Go, Cobra CLI, `miekg/dns` (already a dependency), `portcheck`, `platform`, `certmanager`, `config`, `registry`
+
+**Spec:** `docs/superpowers/specs/2026-03-18-outport-doctor-design.md`
+
+---
+
+### Task 1: `internal/doctor/` — Core types and Runner
+
+**Files:**
+- Create: `internal/doctor/doctor.go`
+- Create: `internal/doctor/doctor_test.go`
+
+- [ ] **Step 1: Write failing tests for Runner**
+
+```go
+// internal/doctor/doctor_test.go
+package doctor
+
+import "testing"
+
+func TestRunnerAllPass(t *testing.T) {
+	r := &Runner{}
+	r.Add(Check{
+		Name:     "check1",
+		Category: "Test",
+		Run: func() *Result {
+			return &Result{Name: "check1", Status: Pass, Message: "ok"}
+		},
+	})
+	r.Add(Check{
+		Name:     "check2",
+		Category: "Test",
+		Run: func() *Result {
+			return &Result{Name: "check2", Status: Pass, Message: "ok"}
+		},
+	})
+	results := r.Run()
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if HasFailures(results) {
+		t.Error("expected no failures")
+	}
+}
+
+func TestRunnerWithWarn(t *testing.T) {
+	r := &Runner{}
+	r.Add(Check{
+		Name:     "warn-check",
+		Category: "Test",
+		Run: func() *Result {
+			return &Result{Name: "warn-check", Status: Warn, Message: "warning", Fix: "do something"}
+		},
+	})
+	results := r.Run()
+	if results[0].Status != Warn {
+		t.Errorf("expected Warn, got %v", results[0].Status)
+	}
+	if HasFailures(results) {
+		t.Error("warnings should not count as failures")
+	}
+}
+
+func TestRunnerWithFail(t *testing.T) {
+	r := &Runner{}
+	r.Add(Check{
+		Name:     "fail-check",
+		Category: "Test",
+		Run: func() *Result {
+			return &Result{Name: "fail-check", Status: Fail, Message: "broken", Fix: "fix it"}
+		},
+	})
+	results := r.Run()
+	if results[0].Status != Fail {
+		t.Errorf("expected Fail, got %v", results[0].Status)
+	}
+	if !HasFailures(results) {
+		t.Error("expected failures")
+	}
+}
+
+func TestRunnerMixed(t *testing.T) {
+	r := &Runner{}
+	r.Add(Check{Name: "a", Category: "Cat1", Run: func() *Result {
+		return &Result{Name: "a", Status: Pass, Message: "ok"}
+	}})
+	r.Add(Check{Name: "b", Category: "Cat1", Run: func() *Result {
+		return &Result{Name: "b", Status: Warn, Message: "meh", Fix: "try this"}
+	}})
+	r.Add(Check{Name: "c", Category: "Cat2", Run: func() *Result {
+		return &Result{Name: "c", Status: Fail, Message: "bad", Fix: "fix it"}
+	}})
+	results := r.Run()
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	// Verify ordering matches insertion order
+	if results[0].Name != "a" || results[1].Name != "b" || results[2].Name != "c" {
+		t.Error("results should preserve insertion order")
+	}
+	if !HasFailures(results) {
+		t.Error("expected failures due to fail check")
+	}
+}
+
+func TestRunnerEmpty(t *testing.T) {
+	r := &Runner{}
+	results := r.Run()
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+	if HasFailures(results) {
+		t.Error("empty results should not have failures")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/doctor/ -v`
+Expected: FAIL — package does not exist yet
+
+- [ ] **Step 3: Write the implementation**
+
+```go
+// internal/doctor/doctor.go
+package doctor
+
+// Status represents the outcome of a health check.
+type Status int
+
+const (
+	Pass Status = iota
+	Warn
+	Fail
+)
+
+// String returns the lowercase status label for JSON output.
+func (s Status) String() string {
+	switch s {
+	case Pass:
+		return "pass"
+	case Warn:
+		return "warn"
+	case Fail:
+		return "fail"
+	default:
+		return "unknown"
+	}
+}
+
+// Check is a single diagnostic check.
+type Check struct {
+	Name     string
+	Category string
+	Run      func() *Result
+}
+
+// Result is the outcome of running a Check.
+type Result struct {
+	Name     string
+	Category string
+	Status   Status
+	Message  string
+	Fix      string
+}
+
+// Runner collects and executes checks sequentially.
+type Runner struct {
+	checks []Check
+}
+
+// Add appends a check to the runner.
+func (r *Runner) Add(c Check) {
+	r.checks = append(r.checks, c)
+}
+
+// Run executes all checks in order and returns the results.
+func (r *Runner) Run() []Result {
+	results := make([]Result, 0, len(r.checks))
+	for _, c := range r.checks {
+		res := c.Run()
+		res.Category = c.Category
+		results = append(results, *res)
+	}
+	return results
+}
+
+// HasFailures returns true if any result has Fail status.
+func HasFailures(results []Result) bool {
+	for _, r := range results {
+		if r.Status == Fail {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/doctor/ -v`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/doctor/doctor.go internal/doctor/doctor_test.go
+git commit -m "feat(doctor): add core types and Runner"
+```
+
+---
+
+### Task 2: Export platform helpers for doctor
+
+**Files:**
+- Modify: `internal/platform/darwin.go`
+
+This task exports `PlistPath()`, `ResolverPath`, `ResolverContent`, and adds `IsCATrusted()`. Also updates `WriteResolverFile()` to use the new constant.
+
+- [ ] **Step 1: Write failing test for IsCATrusted**
+
+No unit test for `IsCATrusted` — it shells out to `security verify-cert` which requires macOS system state. We'll verify it works via manual `outport doctor` invocation during integration testing. The function is a thin wrapper.
+
+- [ ] **Step 2: Add exports and IsCATrusted**
+
+In `internal/platform/darwin.go`:
+
+1. Export the resolver content as a constant and use it in `WriteResolverFile`:
+```go
+const (
+	ResolverPath    = "/etc/resolver/test"
+	ResolverContent = "nameserver 127.0.0.1\nport 15353\n"
+	plistName       = "dev.outport.daemon.plist"
+	plistLabel      = "dev.outport.daemon"
+)
+```
+
+2. Rename `resolverPath` usages to `ResolverPath` throughout the file.
+
+3. Update `WriteResolverFile` to use `ResolverContent` instead of the local `content` variable.
+
+4. Export `plistPath` as `PlistPath`:
+```go
+// PlistPath returns the path to the LaunchAgent plist file.
+func PlistPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", plistName)
+}
+```
+
+5. Update all internal callers of `plistPath()` to `PlistPath()`.
+
+6. Add `IsCATrusted`:
+```go
+// IsCATrusted checks if the CA certificate is trusted in the system keychain
+// by running "security verify-cert".
+func IsCATrusted(certPath string) bool {
+	err := exec.Command("security", "verify-cert", "-c", certPath).Run()
+	return err == nil
+}
+```
+
+- [ ] **Step 3: Run full test suite to verify no regressions**
+
+Run: `go test ./... -count=1`
+Expected: PASS
+
+- [ ] **Step 4: Run lint**
+
+Run: `golangci-lint run`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/darwin.go
+git commit -m "refactor(platform): export PlistPath, ResolverPath, ResolverContent; add IsCATrusted"
+```
+
+---
+
+### Task 3: System checks — file and process checks
+
+**Files:**
+- Create: `internal/doctor/checks.go`
+- Create: `internal/doctor/checks_test.go`
+
+These are the checks that don't require network I/O: resolver file (1-2), plist (3-4), agent loaded (5), CA files (9-10), CA expiry (11), CA trusted (12), registry (13), cloudflared (14).
+
+- [ ] **Step 1: Write failing tests for testable check logic**
+
+```go
+// internal/doctor/checks_test.go
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckResolverContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test")
+
+	// Missing file
+	res := checkResolverContent(path, "nameserver 127.0.0.1\nport 15353\n")
+	if res.Status != Fail {
+		t.Errorf("expected Fail for missing file, got %v", res.Status)
+	}
+
+	// Wrong content
+	os.WriteFile(path, []byte("wrong"), 0644)
+	res = checkResolverContent(path, "nameserver 127.0.0.1\nport 15353\n")
+	if res.Status != Fail {
+		t.Errorf("expected Fail for wrong content, got %v", res.Status)
+	}
+
+	// Correct content
+	os.WriteFile(path, []byte("nameserver 127.0.0.1\nport 15353\n"), 0644)
+	res = checkResolverContent(path, "nameserver 127.0.0.1\nport 15353\n")
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v", res.Status)
+	}
+}
+
+func TestCheckFileExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "exists")
+
+	// Missing
+	res := checkFileExists(path, "test file", "fix it")
+	if res.Status != Fail {
+		t.Errorf("expected Fail, got %v", res.Status)
+	}
+
+	// Exists
+	os.WriteFile(path, []byte("x"), 0644)
+	res = checkFileExists(path, "test file", "fix it")
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v", res.Status)
+	}
+}
+
+func TestCheckPlistBinary(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "test.plist")
+	binaryPath := filepath.Join(dir, "outport")
+
+	// Use a realistic plist matching the actual structure from platform.GeneratePlist —
+	// includes Label, RunAtLoad, KeepAlive, Sockets, and StandardOut/ErrorPath keys
+	// to ensure the XML parser correctly finds ProgramArguments among other keys.
+	plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.outport.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>` + binaryPath + `</string>
+        <string>daemon</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>Sockets</key>
+    <dict>
+        <key>HTTPSocket</key>
+        <dict>
+            <key>SockNodeName</key>
+            <string>127.0.0.1</string>
+            <key>SockServiceName</key>
+            <string>80</string>
+        </dict>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/outport-daemon.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/outport-daemon.log</string>
+</dict>
+</plist>`
+	os.WriteFile(plistPath, []byte(plist), 0644)
+	os.WriteFile(binaryPath, []byte("binary"), 0755)
+
+	res := checkPlistBinary(plistPath)
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v: %s", res.Status, res.Message)
+	}
+
+	// Binary doesn't exist
+	os.Remove(binaryPath)
+	res = checkPlistBinary(plistPath)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for missing binary, got %v", res.Status)
+	}
+
+	// Malformed plist
+	os.WriteFile(plistPath, []byte("not xml"), 0644)
+	res = checkPlistBinary(plistPath)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for malformed plist, got %v", res.Status)
+	}
+}
+
+func TestParsePlistBinaryPath(t *testing.T) {
+	// Minimal plist with just ProgramArguments
+	minimal := []byte(`<?xml version="1.0"?><plist><dict><key>ProgramArguments</key><array><string>/usr/local/bin/outport</string><string>daemon</string></array></dict></plist>`)
+	if got := parsePlistBinaryPath(minimal); got != "/usr/local/bin/outport" {
+		t.Errorf("expected /usr/local/bin/outport, got %q", got)
+	}
+
+	// Empty input
+	if got := parsePlistBinaryPath([]byte("")); got != "" {
+		t.Errorf("expected empty string for empty input, got %q", got)
+	}
+
+	// No ProgramArguments key
+	noProg := []byte(`<?xml version="1.0"?><plist><dict><key>Label</key><string>test</string></dict></plist>`)
+	if got := parsePlistBinaryPath(noProg); got != "" {
+		t.Errorf("expected empty string for missing ProgramArguments, got %q", got)
+	}
+}
+
+func TestCheckCertExpiry(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-cert.pem")
+
+	// Missing file
+	res := checkCertExpiry(certPath)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for missing cert, got %v", res.Status)
+	}
+
+	// Not a valid PEM — just garbage
+	os.WriteFile(certPath, []byte("not a cert"), 0644)
+	res = checkCertExpiry(certPath)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for invalid cert, got %v", res.Status)
+	}
+}
+
+func TestCheckRegistryValid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+
+	// Missing file → Warn
+	res := checkRegistryValid(path)
+	if res.Status != Warn {
+		t.Errorf("expected Warn for missing registry, got %v", res.Status)
+	}
+
+	// Valid JSON
+	os.WriteFile(path, []byte(`{"projects":{}}`), 0644)
+	res = checkRegistryValid(path)
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v", res.Status)
+	}
+
+	// Invalid JSON → Fail
+	os.WriteFile(path, []byte(`{broken`), 0644)
+	res = checkRegistryValid(path)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for corrupt registry, got %v", res.Status)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/doctor/ -v -run "TestCheck"`
+Expected: FAIL — functions don't exist yet
+
+- [ ] **Step 3: Write the check implementations**
+
+```go
+// internal/doctor/checks.go
+package doctor
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/outport-app/outport/internal/certmanager"
+	"github.com/outport-app/outport/internal/platform"
+	"github.com/outport-app/outport/internal/portcheck"
+	"github.com/outport-app/outport/internal/registry"
+)
+
+// checkFileExists checks that a file exists at the given path.
+func checkFileExists(path, name, fix string) *Result {
+	if _, err := os.Stat(path); err != nil {
+		return &Result{
+			Name:    name,
+			Status:  Fail,
+			Message: fmt.Sprintf("%s not found", name),
+			Fix:     fix,
+		}
+	}
+	return &Result{
+		Name:    name,
+		Status:  Pass,
+		Message: fmt.Sprintf("%s (%s)", name, path),
+	}
+}
+
+// checkResolverContent verifies the resolver file has the expected content.
+func checkResolverContent(path, expected string) *Result {
+	name := "DNS resolver content correct"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return &Result{Name: name, Status: Fail, Message: "could not read resolver file", Fix: "Run: outport system start"}
+	}
+	if string(data) != expected {
+		return &Result{Name: name, Status: Fail, Message: "resolver file has unexpected content", Fix: "Run: outport system start"}
+	}
+	return &Result{Name: name, Status: Pass, Message: "DNS resolver content correct"}
+}
+
+// checkPlistBinary parses the plist XML using token-based parsing to find
+// the ProgramArguments array and verify the binary path exists.
+// We use token-based parsing because encoding/xml struct unmarshalling
+// collects <key> and <array> elements independently, breaking the
+// positional correspondence needed to match keys to their values.
+func checkPlistBinary(plistPath string) *Result {
+	name := "LaunchAgent plist binary valid"
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		return &Result{Name: name, Status: Fail, Message: "could not read plist file", Fix: "Run: outport system restart"}
+	}
+
+	binaryPath := parsePlistBinaryPath(data)
+	if binaryPath == "" {
+		return &Result{Name: name, Status: Fail, Message: "could not find binary path in plist", Fix: "Run: outport system restart"}
+	}
+
+	if _, err := os.Stat(binaryPath); err != nil {
+		return &Result{
+			Name:    name,
+			Status:  Fail,
+			Message: fmt.Sprintf("plist references missing binary: %s", binaryPath),
+			Fix:     "Run: outport system restart",
+		}
+	}
+
+	return &Result{Name: name, Status: Pass, Message: "LaunchAgent plist binary valid"}
+}
+
+// parsePlistBinaryPath extracts the first string from the ProgramArguments
+// array in a plist XML document using token-based parsing.
+func parsePlistBinaryPath(data []byte) string {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	// Walk tokens looking for <key>ProgramArguments</key> followed by <array><string>...</string>
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			return ""
+		}
+		// Look for <key> elements
+		start, ok := tok.(xml.StartElement)
+		if !ok || start.Name.Local != "key" {
+			continue
+		}
+		// Read the key text
+		var keyText string
+		if err := decoder.DecodeElement(&keyText, &start); err != nil {
+			return ""
+		}
+		if keyText != "ProgramArguments" {
+			continue
+		}
+		// Next non-whitespace token should be <array>
+		for {
+			tok, err = decoder.Token()
+			if err != nil {
+				return ""
+			}
+			if arr, ok := tok.(xml.StartElement); ok {
+				if arr.Name.Local != "array" {
+					return ""
+				}
+				// Read first <string> inside the array
+				for {
+					tok, err = decoder.Token()
+					if err != nil {
+						return ""
+					}
+					if s, ok := tok.(xml.StartElement); ok {
+						if s.Name.Local == "string" {
+							var val string
+							if err := decoder.DecodeElement(&val, &s); err != nil {
+								return ""
+							}
+							return val
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// checkAgentLoaded checks if the LaunchAgent is loaded via launchctl.
+func checkAgentLoaded() *Result {
+	name := "LaunchAgent loaded"
+	if platform.IsAgentLoaded() {
+		return &Result{Name: name, Status: Pass, Message: "LaunchAgent loaded"}
+	}
+	return &Result{Name: name, Status: Fail, Message: "LaunchAgent not loaded", Fix: "Run: outport system start"}
+}
+
+// checkPortUp verifies a port is accepting connections.
+func checkPortUp(port int, name, fix string) *Result {
+	if portcheck.IsUp(port) {
+		return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("%s (port %d)", name, port)}
+	}
+	return &Result{Name: name, Status: Fail, Message: fmt.Sprintf("%s not responding", name), Fix: fix}
+}
+
+// checkCertExpiry parses a PEM certificate and checks it hasn't expired.
+func checkCertExpiry(certPath string) *Result {
+	name := "CA certificate not expired"
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return &Result{Name: name, Status: Fail, Message: "could not read CA certificate", Fix: "Run: outport system start"}
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return &Result{Name: name, Status: Fail, Message: "CA certificate is not valid PEM", Fix: "Run: outport system uninstall && outport system start"}
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return &Result{Name: name, Status: Fail, Message: "could not parse CA certificate", Fix: "Run: outport system uninstall && outport system start"}
+	}
+
+	if time.Now().After(cert.NotAfter) {
+		return &Result{
+			Name:    name,
+			Status:  Fail,
+			Message: fmt.Sprintf("CA certificate expired on %s", cert.NotAfter.Format("2006-01-02")),
+			Fix:     "Run: outport system uninstall && outport system start",
+		}
+	}
+
+	return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("CA certificate not expired (expires %s)", cert.NotAfter.Format("2006-01-02"))}
+}
+
+// checkCATrusted checks if the CA is trusted in the system keychain.
+func checkCATrusted(certPath string) *Result {
+	name := "CA trusted in system keychain"
+	if platform.IsCATrusted(certPath) {
+		return &Result{Name: name, Status: Pass, Message: "CA trusted in system keychain"}
+	}
+	return &Result{Name: name, Status: Fail, Message: "CA not trusted in system keychain", Fix: "Run: outport system start"}
+}
+
+// checkRegistryValid checks that the registry file exists and is valid JSON.
+func checkRegistryValid(path string) *Result {
+	name := "Registry file valid"
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return &Result{Name: name, Status: Warn, Message: "Registry file not found (no projects registered yet)", Fix: "Run: outport up in a project directory"}
+	}
+
+	if _, err := registry.Load(path); err != nil {
+		return &Result{Name: name, Status: Fail, Message: fmt.Sprintf("Registry file is corrupt: %v", err), Fix: "Delete and re-register projects: rm ~/.local/share/outport/registry.json && outport up"}
+	}
+
+	return &Result{Name: name, Status: Pass, Message: "Registry file valid"}
+}
+
+// checkCloudflared checks if cloudflared is available in PATH.
+func checkCloudflared() *Result {
+	name := "cloudflared installed"
+	if _, err := exec.LookPath("cloudflared"); err != nil {
+		return &Result{Name: name, Status: Warn, Message: "cloudflared not installed (sharing will not work)", Fix: "Install with: brew install cloudflared"}
+	}
+	return &Result{Name: name, Status: Pass, Message: "cloudflared installed"}
+}
+
+// SystemChecks returns all system-level health checks.
+func SystemChecks() []Check {
+	caCertPath, _ := certmanager.CACertPath()
+	caKeyPath, _ := certmanager.CAKeyPath()
+	regPath, _ := registry.DefaultPath()
+	plistPath := platform.PlistPath()
+
+	return []Check{
+		{Name: "DNS resolver file exists", Category: "System", Run: func() *Result {
+			return checkFileExists(platform.ResolverPath, "DNS resolver file exists", "Run: outport system start")
+		}},
+		{Name: "DNS resolver content correct", Category: "System", Run: func() *Result {
+			return checkResolverContent(platform.ResolverPath, platform.ResolverContent)
+		}},
+		{Name: "LaunchAgent plist installed", Category: "System", Run: func() *Result {
+			return checkFileExists(plistPath, "LaunchAgent plist installed", "Run: outport system start")
+		}},
+		{Name: "LaunchAgent plist binary valid", Category: "System", Run: func() *Result {
+			return checkPlistBinary(plistPath)
+		}},
+		{Name: "LaunchAgent loaded", Category: "System", Run: checkAgentLoaded},
+		{Name: "HTTP proxy responding", Category: "System", Run: func() *Result {
+			return checkPortUp(80, "HTTP proxy responding", "Run: outport system restart")
+		}},
+		{Name: "HTTPS proxy responding", Category: "System", Run: func() *Result {
+			return checkPortUp(443, "HTTPS proxy responding", "Run: outport system restart")
+		}},
+		{Name: "CA certificate exists", Category: "System", Run: func() *Result {
+			return checkFileExists(caCertPath, "CA certificate exists", "Run: outport system start")
+		}},
+		{Name: "CA private key exists", Category: "System", Run: func() *Result {
+			return checkFileExists(caKeyPath, "CA private key exists", "Run: outport system start")
+		}},
+		{Name: "CA certificate not expired", Category: "System", Run: func() *Result {
+			return checkCertExpiry(caCertPath)
+		}},
+		{Name: "CA trusted in system keychain", Category: "System", Run: func() *Result {
+			return checkCATrusted(caCertPath)
+		}},
+		{Name: "Registry file valid", Category: "System", Run: func() *Result {
+			return checkRegistryValid(regPath)
+		}},
+		{Name: "cloudflared installed", Category: "System", Run: checkCloudflared},
+	}
+}
+```
+
+Note: DNS resolution check (check #6 from the spec) is deferred to Task 4 as it requires `miekg/dns`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/doctor/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Run lint**
+
+Run: `golangci-lint run ./internal/doctor/`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/doctor/checks.go internal/doctor/checks_test.go
+git commit -m "feat(doctor): add system check implementations"
+```
+
+---
+
+### Task 4: DNS resolution check
+
+**Files:**
+- Create: `internal/doctor/dns.go`
+- Modify: `internal/doctor/checks.go` (add DNS check to `SystemChecks()`)
+
+- [ ] **Step 1: Write the DNS check function**
+
+```go
+// internal/doctor/dns.go
+package doctor
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// checkDNSResolving sends a UDP query to the given resolver address for
+// "outport-check.test" and verifies it returns 127.0.0.1.
+func checkDNSResolving(resolverAddr string) *Result {
+	name := "DNS resolving *.test"
+
+	c := new(dns.Client)
+	c.Timeout = 2 * time.Second
+
+	m := new(dns.Msg)
+	m.SetQuestion("outport-check.test.", dns.TypeA)
+
+	r, _, err := c.Exchange(m, resolverAddr)
+	if err != nil {
+		return &Result{
+			Name:    name,
+			Status:  Fail,
+			Message: fmt.Sprintf("DNS query failed: %v", err),
+			Fix:     "Run: outport system restart",
+		}
+	}
+
+	if len(r.Answer) == 0 {
+		return &Result{Name: name, Status: Fail, Message: "DNS query returned no answers", Fix: "Run: outport system restart"}
+	}
+
+	for _, ans := range r.Answer {
+		if a, ok := ans.(*dns.A); ok {
+			if a.A.Equal(net.IPv4(127, 0, 0, 1)) {
+				return &Result{Name: name, Status: Pass, Message: "DNS resolving *.test → 127.0.0.1"}
+			}
+		}
+	}
+
+	return &Result{Name: name, Status: Fail, Message: "DNS query did not return 127.0.0.1", Fix: "Run: outport system restart"}
+}
+```
+
+- [ ] **Step 2: Add DNS check to SystemChecks in checks.go**
+
+Insert the DNS check between "LaunchAgent loaded" and "HTTP proxy responding" in the `SystemChecks()` slice:
+
+```go
+{Name: "DNS resolving *.test", Category: "System", Run: func() *Result {
+	return checkDNSResolving("127.0.0.1:15353")
+}},
+```
+
+- [ ] **Step 3: Run tests and lint**
+
+Run: `go test ./internal/doctor/ -v && golangci-lint run ./internal/doctor/`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/doctor/dns.go internal/doctor/checks.go
+git commit -m "feat(doctor): add DNS resolution check"
+```
+
+---
+
+### Task 5: Project checks
+
+**Files:**
+- Create: `internal/doctor/project.go`
+- Create: `internal/doctor/project_test.go`
+
+- [ ] **Step 1: Write failing tests for project checks**
+
+```go
+// internal/doctor/project_test.go
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckConfigValid(t *testing.T) {
+	dir := t.TempDir()
+
+	// Valid config
+	cfg := `name: myapp
+services:
+  web:
+    env_var: PORT
+`
+	os.WriteFile(filepath.Join(dir, ".outport.yml"), []byte(cfg), 0644)
+	res := checkConfigValid(dir)
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v: %s", res.Status, res.Message)
+	}
+
+	// Invalid config (missing name)
+	os.WriteFile(filepath.Join(dir, ".outport.yml"), []byte("services:\n  web:\n    env_var: PORT\n"), 0644)
+	res = checkConfigValid(dir)
+	if res.Status != Fail {
+		t.Errorf("expected Fail, got %v", res.Status)
+	}
+}
+
+func TestCheckProjectRegistered(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+
+	// Empty registry
+	os.WriteFile(regPath, []byte(`{"projects":{}}`), 0644)
+	res := checkProjectRegistered(regPath, dir)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for unregistered project, got %v", res.Status)
+	}
+
+	// Registered
+	os.WriteFile(regPath, []byte(`{"projects":{"myapp/main":{"project_dir":"`+dir+`","ports":{"web":3000}}}}`), 0644)
+	res = checkProjectRegistered(regPath, dir)
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v: %s", res.Status, res.Message)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/doctor/ -v -run "TestCheckConfig|TestCheckProject"`
+Expected: FAIL
+
+- [ ] **Step 3: Write the project check implementations**
+
+```go
+// internal/doctor/project.go
+package doctor
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/outport-app/outport/internal/config"
+	"github.com/outport-app/outport/internal/portcheck"
+	"github.com/outport-app/outport/internal/registry"
+)
+
+// checkConfigValid attempts to load and validate the .outport.yml in dir.
+func checkConfigValid(dir string) *Result {
+	name := ".outport.yml valid"
+	_, err := config.Load(dir)
+	if err != nil {
+		return &Result{Name: name, Status: Fail, Message: fmt.Sprintf(".outport.yml: %v", err)}
+	}
+	return &Result{Name: name, Status: Pass, Message: ".outport.yml valid"}
+}
+
+// checkProjectRegistered checks if the current directory is registered in the registry.
+func checkProjectRegistered(regPath, dir string) *Result {
+	name := "Project registered"
+	reg, err := registry.Load(regPath)
+	if err != nil {
+		return &Result{Name: name, Status: Fail, Message: fmt.Sprintf("could not load registry: %v", err)}
+	}
+	key, _, found := reg.FindByDir(dir)
+	if !found {
+		return &Result{Name: name, Status: Fail, Message: "project not registered", Fix: "Run: outport up"}
+	}
+	return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("Project registered (%s)", key)}
+}
+
+// checkPortAvailable checks if an allocated port is in use.
+// Returns Warn (not Fail) because the service itself may be running.
+func checkPortAvailable(port int, serviceName string) *Result {
+	name := fmt.Sprintf("Port %d (%s)", port, serviceName)
+	if portcheck.IsUp(port) {
+		return &Result{Name: name, Status: Warn, Message: fmt.Sprintf("Port %d (%s) is in use", port, serviceName)}
+	}
+	return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("Port %d (%s) available", port, serviceName)}
+}
+
+// ProjectChecks returns project-level health checks for the given directory.
+// cfg may be nil if config loading failed (in which case only the config check is returned).
+// regPath is the path to registry.json.
+func ProjectChecks(dir string, cfg *config.Config, configErr error, regPath string) []Check {
+	category := "Project"
+	if cfg != nil {
+		category = fmt.Sprintf("Project (%s)", cfg.Name)
+	}
+
+	var checks []Check
+
+	// Config validity check
+	if configErr != nil {
+		checks = append(checks, Check{
+			Name:     ".outport.yml valid",
+			Category: category,
+			Run: func() *Result {
+				return &Result{Name: ".outport.yml valid", Status: Fail, Message: fmt.Sprintf(".outport.yml: %v", configErr)}
+			},
+		})
+		return checks // Skip remaining project checks
+	}
+
+	checks = append(checks, Check{
+		Name:     ".outport.yml valid",
+		Category: category,
+		Run: func() *Result {
+			return &Result{Name: ".outport.yml valid", Status: Pass, Message: ".outport.yml valid"}
+		},
+	})
+
+	// Registration check
+	checks = append(checks, Check{
+		Name:     "Project registered",
+		Category: category,
+		Run: func() *Result {
+			return checkProjectRegistered(regPath, dir)
+		},
+	})
+
+	// Port checks — load registry to get allocated ports
+	reg, err := registry.Load(regPath)
+	if err == nil {
+		if _, alloc, found := reg.FindByDir(dir); found {
+			serviceNames := make([]string, 0, len(alloc.Ports))
+			for name := range alloc.Ports {
+				serviceNames = append(serviceNames, name)
+			}
+			sort.Strings(serviceNames)
+			for _, svcName := range serviceNames {
+				port := alloc.Ports[svcName]
+				svc := svcName // capture for closure
+				p := port
+				checks = append(checks, Check{
+					Name:     fmt.Sprintf("Port %d (%s)", p, svc),
+					Category: category,
+					Run: func() *Result {
+						return checkPortAvailable(p, svc)
+					},
+				})
+			}
+		}
+	}
+
+	return checks
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/doctor/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/doctor/project.go internal/doctor/project_test.go
+git commit -m "feat(doctor): add project-level checks"
+```
+
+---
+
+### Task 6: `cmd/doctor.go` — Command wiring and output
+
+**Files:**
+- Modify: `cmd/cmdutil.go` (add `SilentError` sentinel)
+- Modify: `main.go` (suppress output for `SilentError`)
+- Create: `cmd/doctor.go`
+
+- [ ] **Step 1: Add SilentError sentinel to cmdutil.go**
+
+Add to `cmd/cmdutil.go`:
+
+```go
+// SilentError is returned when a command wants to set exit code 1
+// without printing an error message. main.go checks for this.
+var SilentError = errors.New("")
+```
+
+Update `main.go` to suppress output for SilentError:
+
+```go
+func main() {
+	if err := cmd.Execute(); err != nil {
+		if err != cmd.SilentError {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		os.Exit(1)
+	}
+}
+```
+
+- [ ] **Step 2: Write the command**
+
+```go
+// cmd/doctor.go
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"charm.land/lipgloss/v2"
+	"github.com/outport-app/outport/internal/config"
+	"github.com/outport-app/outport/internal/doctor"
+	"github.com/outport-app/outport/internal/registry"
+	"github.com/outport-app/outport/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var doctorCmd = &cobra.Command{
+	Use:     "doctor",
+	Short:   "Check the health of the outport system",
+	Long:    "Runs diagnostic checks on DNS, daemon, certificates, registry, and project configuration. Reports pass/warn/fail for each check with actionable fix suggestions.",
+	GroupID: "project",
+	Args:    NoArgs,
+	RunE:    runDoctor,
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	r := &doctor.Runner{}
+
+	// System checks (always)
+	for _, c := range doctor.SystemChecks() {
+		r.Add(c)
+	}
+
+	// Project checks (when .outport.yml found)
+	cwd, err := os.Getwd()
+	if err == nil {
+		if dir, findErr := config.FindDir(cwd); findErr == nil {
+			regPath, _ := registry.DefaultPath()
+			cfg, configErr := config.Load(dir)
+			for _, c := range doctor.ProjectChecks(dir, cfg, configErr, regPath) {
+				r.Add(c)
+			}
+		}
+	}
+
+	results := r.Run()
+
+	if jsonFlag {
+		return printDoctorJSON(cmd, results)
+	}
+
+	printDoctorStyled(cmd.OutOrStdout(), results)
+
+	if doctor.HasFailures(results) {
+		return SilentError
+	}
+	return nil
+}
+
+// JSON output
+
+type resultJSON struct {
+	Name     string `json:"name"`
+	Category string `json:"category"`
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	Fix      string `json:"fix,omitempty"`
+}
+
+type doctorJSON struct {
+	Results []resultJSON `json:"results"`
+	Passed  bool         `json:"passed"`
+}
+
+func printDoctorJSON(cmd *cobra.Command, results []doctor.Result) error {
+	out := doctorJSON{
+		Passed: !doctor.HasFailures(results),
+	}
+	for _, r := range results {
+		out.Results = append(out.Results, resultJSON{
+			Name:     r.Name,
+			Category: r.Category,
+			Status:   r.Status.String(),
+			Message:  r.Message,
+			Fix:      r.Fix,
+		})
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return nil
+}
+
+// Styled output
+
+func printDoctorStyled(w io.Writer, results []doctor.Result) {
+	currentCategory := ""
+	for _, r := range results {
+		if r.Category != currentCategory {
+			if currentCategory != "" {
+				lipgloss.Fprintln(w) // blank line between categories
+			}
+			lipgloss.Fprintln(w, ui.ProjectStyle.Render(r.Category))
+			currentCategory = r.Category
+		}
+
+		var icon string
+		switch r.Status {
+		case doctor.Pass:
+			icon = lipgloss.NewStyle().Foreground(ui.Green).Render("✓")
+		case doctor.Warn:
+			icon = lipgloss.NewStyle().Foreground(ui.Yellow).Render("!")
+		case doctor.Fail:
+			icon = lipgloss.NewStyle().Foreground(ui.Red).Render("✗")
+		}
+
+		lipgloss.Fprintln(w, fmt.Sprintf("  %s %s", icon, r.Message))
+
+		if r.Fix != "" {
+			lipgloss.Fprintln(w, fmt.Sprintf("    %s %s", ui.Arrow, ui.DimStyle.Render(r.Fix)))
+		}
+	}
+
+	lipgloss.Fprintln(w)
+	if doctor.HasFailures(results) {
+		lipgloss.Fprintln(w, lipgloss.NewStyle().Foreground(ui.Red).Render("Some checks failed. See suggestions above."))
+	} else {
+		lipgloss.Fprintln(w, ui.SuccessStyle.Render("All checks passed."))
+	}
+}
+```
+
+- [ ] **Step 2: Build and verify it compiles**
+
+Run: `just build`
+Expected: Compiles without errors
+
+- [ ] **Step 3: Run lint**
+
+Run: `golangci-lint run ./cmd/ ./internal/doctor/`
+Expected: PASS
+
+- [ ] **Step 4: Manual smoke test**
+
+Run: `just run doctor`
+Expected: Output showing system checks with ✓/✗/! indicators
+
+Run: `just run doctor --json`
+Expected: JSON output with results array and passed field
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/doctor.go
+git commit -m "feat: add outport doctor command
+
+Diagnostic command that checks the health of all Outport infrastructure:
+DNS resolver, daemon, CA certificates, registry, and project config.
+Supports --json for machine-readable output.
+
+Closes #35"
+```
+
+---
+
+### Task 7: Full test suite + lint verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `just test`
+Expected: All tests pass
+
+- [ ] **Step 2: Run lint**
+
+Run: `just lint`
+Expected: No lint errors
+
+- [ ] **Step 3: Verify --json output**
+
+Run: `just run doctor --json | python3 -m json.tool`
+Expected: Valid JSON with proper structure

--- a/docs/superpowers/specs/2026-03-18-outport-doctor-design.md
+++ b/docs/superpowers/specs/2026-03-18-outport-doctor-design.md
@@ -1,0 +1,209 @@
+# `outport doctor` — Diagnostic Command
+
+**Date:** 2026-03-18
+**Issue:** #35 (supersedes #9)
+
+## Summary
+
+A top-level `outport doctor` command that checks the health of all Outport infrastructure and reports pass/warn/fail for each check with actionable fix suggestions. Read-only — never modifies system state.
+
+## Command
+
+```
+outport doctor [--json]
+```
+
+- Top-level command (not under `system`), since it checks both system and project health.
+- Supports `--json` for machine-readable output.
+- Exit code 0 if all checks pass or warn. Exit code 1 if any check fails.
+
+## Architecture
+
+### Package: `internal/doctor/`
+
+Core types:
+
+```go
+type Status int
+
+const (
+    Pass Status = iota
+    Warn
+    Fail
+)
+
+type Check struct {
+    Name     string
+    Category string         // "System" or "Project (myapp)" — project name comes from config.Name
+    Run      func() *Result
+}
+
+type Result struct {
+    Name    string
+    Status  Status
+    Message string // human-readable description of what was checked
+    Fix     string `json:"fix,omitempty"` // actionable suggestion on fail/warn, omitted on pass
+}
+
+type Runner struct {
+    checks []Check
+}
+```
+
+Runner methods:
+
+- `Add(check Check)` — appends a check.
+- `Run() []Result` — executes all checks sequentially, returns results.
+
+Sequential execution because checks are fast (file stats, single TCP dials at ~200ms) and order matters for readable output. No dependency or short-circuiting between checks — every check runs independently so the user sees the full picture.
+
+### Command: `cmd/doctor.go`
+
+Registers checks and handles output:
+
+1. Always registers system checks.
+2. Gets the working directory via `os.Getwd()`, then attempts `config.FindDir(cwd)` (matching existing command patterns like `loadProjectContext()`):
+   - If found, loads config once via `config.Load(dir)`. If config is valid, registers project checks using the loaded config and dir. If config is invalid, registers a single failing config check and skips remaining project checks.
+   - If no `.outport.yml` found, no project checks are added (no error).
+3. Runs all checks via the Runner.
+4. Outputs styled or JSON results.
+
+**Implementation notes:**
+
+- `platform.plistPath()` is currently unexported — export it as `platform.PlistPath()` so the doctor can stat and parse the plist file.
+- The resolver content string (`"nameserver 127.0.0.1\nport 15353\n"`) should be extracted as `platform.ResolverContent` so the doctor check can't drift from `WriteResolverFile()`.
+- CA trust verification needs a new `platform.IsCA Trusted(certPath string) bool` function wrapping `security verify-cert -c {certPath}`.
+- Registry check #13 requires a two-step approach: first `os.Stat` the registry path (missing → Warn), then `registry.Load()` (parse error → Fail). This is because `registry.Load()` returns `(emptyRegistry, nil)` for missing files — it doesn't error.
+- DNS resolution check #6 introduces new logic (UDP query via `miekg/dns`) not wrapped by an existing function. Extract this into a testable function that accepts a resolver address.
+
+## Output Format
+
+### Styled (default)
+
+```
+System
+  ✓ DNS resolver file exists (/etc/resolver/test)
+  ✓ DNS resolver content correct
+  ✓ LaunchAgent plist installed
+  ✓ LaunchAgent plist binary valid
+  ✓ LaunchAgent loaded
+  ✓ DNS resolving *.test → 127.0.0.1
+  ✓ HTTP proxy responding (port 80)
+  ✓ HTTPS proxy responding (port 443)
+  ✓ CA certificate exists
+  ✓ CA private key exists
+  ✓ CA certificate not expired
+  ✓ CA trusted in system keychain
+  ✓ Registry file valid
+  ✓ cloudflared installed
+
+Project (myapp)
+  ✓ .outport.yml valid
+  ✓ Project registered (myapp/main)
+  ✓ Port 12345 (web) available
+  ✓ Port 12346 (postgres) available
+
+All checks passed.
+```
+
+Failures:
+
+```
+  ✗ LaunchAgent not loaded
+    → Run: outport system start
+```
+
+Warnings:
+
+```
+  ! cloudflared not installed
+    → Install with: brew install cloudflared
+```
+
+### Severity Levels
+
+- **Pass** — check succeeded.
+- **Warn** — not broken, but worth knowing. Does not affect exit code.
+- **Fail** — something is broken. Causes exit code 1.
+
+### JSON
+
+```json
+{
+  "results": [
+    {
+      "name": "DNS resolver file exists",
+      "category": "System",
+      "status": "pass",
+      "message": "DNS resolver file exists (/etc/resolver/test)"
+    },
+    {
+      "name": "cloudflared installed",
+      "category": "System",
+      "status": "warn",
+      "message": "cloudflared not installed",
+      "fix": "Install with: brew install cloudflared"
+    }
+  ],
+  "passed": true
+}
+```
+
+`passed` is `false` if any result has status `"fail"`.
+
+## Checks
+
+### System Checks (always run)
+
+| # | Check | Implementation | On Failure |
+|---|-------|---------------|------------|
+| 1 | DNS resolver file exists | `os.Stat("/etc/resolver/test")` | Fail → `outport system start` |
+| 2 | DNS resolver content correct | `os.ReadFile`, compare to `"nameserver 127.0.0.1\nport 15353\n"` | Fail → `outport system start` |
+| 3 | LaunchAgent plist installed | `os.Stat(plistPath())` | Fail → `outport system start` |
+| 4 | LaunchAgent plist binary valid | Parse plist XML, extract `ProgramArguments[0]`, `os.Stat` the binary | Fail → `outport system restart` |
+| 5 | LaunchAgent loaded | `platform.IsAgentLoaded()` | Fail → `outport system start` |
+| 6 | DNS resolving | UDP query to `127.0.0.1:15353` for `anything.test`, expect A record `127.0.0.1` | Fail → `outport system restart` |
+| 7 | HTTP proxy responding | `portcheck.IsUp(80)` | Fail → `outport system restart` |
+| 8 | HTTPS proxy responding | `portcheck.IsUp(443)` | Fail → `outport system restart` |
+| 9 | CA certificate exists | `os.Stat` on `~/.local/share/outport/ca-cert.pem` | Fail → `outport system start` |
+| 10 | CA private key exists | `os.Stat` on `~/.local/share/outport/ca-key.pem` | Fail → `outport system start` |
+| 11 | CA not expired | Parse x509 cert, check `NotAfter > now()` | Fail → `outport system uninstall && outport system start` |
+| 12 | CA trusted in keychain | `security verify-cert -c {caCertPath}` | Fail → `outport system start` |
+| 13 | Registry file valid | `registry.Load()` — missing file is Warn, parse error is Fail | Warn: no projects yet. Fail: corrupted file. |
+| 14 | cloudflared installed | `exec.LookPath("cloudflared")` | **Warn** → `brew install cloudflared` |
+
+### Project Checks (only when `.outport.yml` found)
+
+| # | Check | Implementation | On Failure |
+|---|-------|---------------|------------|
+| 15 | .outport.yml valid | `config.Load(dir)` — reports the validation error directly | Fail |
+| 16 | Project registered | `reg.FindByDir(dir)` | Fail → `outport up` |
+| 17 | Port available (per service) | `portcheck.IsUp(port)` per allocated port | **Warn** — port in use is informational since the service may legitimately be running |
+
+Port conflict nuance: a port being "in use" isn't necessarily bad — it could be the actual service running. So port checks are Warn not Fail, with a message like "Port 5432 (postgres) is in use".
+
+If `config.Load()` fails (check 15), remaining project checks (16, 17) are skipped since they depend on a valid config.
+
+## Testing
+
+The `internal/doctor/` package is testable via check functions:
+
+**Runner tests:**
+- All-pass checks → `passed: true`, exit 0
+- Runner with a warn → `passed: true`, exit 0
+- Runner with a fail → `passed: false`, exit 1
+- Mixed results → correct ordering, counts, and `passed` value
+
+**Check-specific tests** for logic that isn't trivially delegated:
+- Plist binary path parsing and validation
+- Resolver content comparison
+- CA cert expiry parsing
+
+Individual checks are thin wrappers around existing tested functions (`portcheck.IsUp`, `config.Load`, `registry.Load`, `certmanager.IsCAInstalled`, `platform.IsAgentLoaded`), so they don't need deep unit tests.
+
+## Not In Scope
+
+- **`--fix` auto-repair** — `outport system start` is the repair path. Doctor stays read-only.
+- **`--verbose` flag** — every check is already shown.
+- **`--category` filter** — not enough checks to warrant it.
+- **Concurrent checks** — not worth the complexity for <20 fast checks.

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -1,0 +1,409 @@
+package doctor
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/outport-app/outport/internal/certmanager"
+	"github.com/outport-app/outport/internal/platform"
+	"github.com/outport-app/outport/internal/portcheck"
+	"github.com/outport-app/outport/internal/registry"
+)
+
+// checkFileExists returns Pass if the file at path exists, Fail otherwise.
+func checkFileExists(path, name, fix string) *Result {
+	if _, err := os.Stat(path); err != nil {
+		return &Result{
+			Name:    name,
+			Status:  Fail,
+			Message: fmt.Sprintf("%s not found", name),
+			Fix:     fix,
+		}
+	}
+	return &Result{
+		Name:    name,
+		Status:  Pass,
+		Message: fmt.Sprintf("%s exists", name),
+	}
+}
+
+// checkResolverContent returns Pass if the file at path exists and has the expected content.
+func checkResolverContent(path, expected string) *Result {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return &Result{
+			Name:    "Resolver content",
+			Status:  Fail,
+			Message: "resolver file not found",
+			Fix:     "Run: outport system start",
+		}
+	}
+	if string(data) != expected {
+		return &Result{
+			Name:    "Resolver content",
+			Status:  Fail,
+			Message: "resolver file has unexpected content",
+			Fix:     "Run: outport system start",
+		}
+	}
+	return &Result{
+		Name:    "Resolver content",
+		Status:  Pass,
+		Message: "resolver content is correct",
+	}
+}
+
+// parsePlistBinaryPath extracts the first string from ProgramArguments in a plist XML.
+// Uses token-based XML parsing to preserve positional correspondence between keys and values.
+func parsePlistBinaryPath(data []byte) string {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			return ""
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok || start.Name.Local != "key" {
+			continue
+		}
+		var keyText string
+		if err := decoder.DecodeElement(&keyText, &start); err != nil {
+			return ""
+		}
+		if keyText != "ProgramArguments" {
+			continue
+		}
+		// Next start element should be <array>
+		for {
+			tok, err = decoder.Token()
+			if err != nil {
+				return ""
+			}
+			if arr, ok := tok.(xml.StartElement); ok {
+				if arr.Name.Local != "array" {
+					return ""
+				}
+				// Read first <string> inside the array
+				for {
+					tok, err = decoder.Token()
+					if err != nil {
+						return ""
+					}
+					if s, ok := tok.(xml.StartElement); ok {
+						if s.Name.Local == "string" {
+							var val string
+							if err := decoder.DecodeElement(&val, &s); err != nil {
+								return ""
+							}
+							return val
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// checkPlistBinary reads the plist, extracts the binary path from ProgramArguments,
+// and verifies the binary exists on disk.
+func checkPlistBinary(plistPath string) *Result {
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		return &Result{
+			Name:    "Plist binary",
+			Status:  Fail,
+			Message: "could not read plist file",
+			Fix:     "Run: outport system start",
+		}
+	}
+
+	binPath := parsePlistBinaryPath(data)
+	if binPath == "" {
+		return &Result{
+			Name:    "Plist binary",
+			Status:  Fail,
+			Message: "could not parse binary path from plist",
+			Fix:     "Run: outport system start",
+		}
+	}
+
+	if _, err := os.Stat(binPath); err != nil {
+		return &Result{
+			Name:    "Plist binary",
+			Status:  Fail,
+			Message: fmt.Sprintf("binary not found: %s", binPath),
+			Fix:     "Reinstall outport and run: outport system start",
+		}
+	}
+
+	return &Result{
+		Name:    "Plist binary",
+		Status:  Pass,
+		Message: fmt.Sprintf("binary exists: %s", binPath),
+	}
+}
+
+// checkAgentLoaded returns Pass if the LaunchAgent is loaded.
+func checkAgentLoaded() *Result {
+	if platform.IsAgentLoaded() {
+		return &Result{
+			Name:    "Agent loaded",
+			Status:  Pass,
+			Message: "daemon agent is loaded",
+		}
+	}
+	return &Result{
+		Name:    "Agent loaded",
+		Status:  Fail,
+		Message: "daemon agent is not loaded",
+		Fix:     "Run: outport system start",
+	}
+}
+
+// checkPortUp returns Pass if the given port is accepting connections.
+func checkPortUp(port int, name, fix string) *Result {
+	if portcheck.IsUp(port) {
+		return &Result{
+			Name:    name,
+			Status:  Pass,
+			Message: fmt.Sprintf("port %d is up", port),
+		}
+	}
+	return &Result{
+		Name:    name,
+		Status:  Fail,
+		Message: fmt.Sprintf("port %d is not responding", port),
+		Fix:     fix,
+	}
+}
+
+// checkCertExpiry reads a PEM certificate and checks its expiry.
+// Returns Warn if expiring within 30 days, Fail if expired or unreadable.
+func checkCertExpiry(certPath string) *Result {
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return &Result{
+			Name:    "CA expiry",
+			Status:  Fail,
+			Message: "could not read CA certificate",
+			Fix:     "Run: outport system start",
+		}
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return &Result{
+			Name:    "CA expiry",
+			Status:  Fail,
+			Message: "CA certificate is not valid PEM",
+			Fix:     "Run: outport system uninstall && outport system start",
+		}
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return &Result{
+			Name:    "CA expiry",
+			Status:  Fail,
+			Message: "could not parse CA certificate",
+			Fix:     "Run: outport system uninstall && outport system start",
+		}
+	}
+
+	now := time.Now()
+	if now.After(cert.NotAfter) {
+		return &Result{
+			Name:    "CA expiry",
+			Status:  Fail,
+			Message: fmt.Sprintf("CA certificate expired on %s", cert.NotAfter.Format("2006-01-02")),
+			Fix:     "Run: outport system uninstall && outport system start",
+		}
+	}
+
+	daysLeft := int(time.Until(cert.NotAfter).Hours() / 24)
+	if daysLeft < 30 {
+		return &Result{
+			Name:    "CA expiry",
+			Status:  Warn,
+			Message: fmt.Sprintf("CA certificate expires in %d days", daysLeft),
+			Fix:     "Run: outport system uninstall && outport system start",
+		}
+	}
+
+	return &Result{
+		Name:    "CA expiry",
+		Status:  Pass,
+		Message: fmt.Sprintf("CA certificate valid until %s", cert.NotAfter.Format("2006-01-02")),
+	}
+}
+
+// checkCATrusted returns Pass if the CA certificate is trusted by the system.
+func checkCATrusted(certPath string) *Result {
+	if platform.IsCATrusted(certPath) {
+		return &Result{
+			Name:    "CA trusted",
+			Status:  Pass,
+			Message: "CA certificate is trusted",
+		}
+	}
+	return &Result{
+		Name:    "CA trusted",
+		Status:  Fail,
+		Message: "CA certificate is not trusted",
+		Fix:     "Run: outport system start",
+	}
+}
+
+// checkRegistryValid checks that the registry file exists and is parseable.
+// Missing registry is Warn (normal for fresh installs), corrupt is Fail.
+func checkRegistryValid(path string) *Result {
+	if _, err := os.Stat(path); err != nil {
+		return &Result{
+			Name:    "Registry",
+			Status:  Warn,
+			Message: "registry file not found (normal for fresh installs)",
+		}
+	}
+
+	if _, err := registry.Load(path); err != nil {
+		return &Result{
+			Name:    "Registry",
+			Status:  Fail,
+			Message: fmt.Sprintf("registry is corrupt: %v", err),
+			Fix:     "Remove the registry file and re-run outport up in your projects",
+		}
+	}
+
+	return &Result{
+		Name:    "Registry",
+		Status:  Pass,
+		Message: "registry is valid",
+	}
+}
+
+// checkCloudflared returns Pass if cloudflared is on the PATH.
+func checkCloudflared() *Result {
+	path, err := exec.LookPath("cloudflared")
+	if err != nil {
+		return &Result{
+			Name:    "cloudflared",
+			Status:  Warn,
+			Message: "cloudflared not found (needed for outport share)",
+			Fix:     "Install cloudflared: brew install cloudflare/cloudflare/cloudflared",
+		}
+	}
+	return &Result{
+		Name:    "cloudflared",
+		Status:  Pass,
+		Message: fmt.Sprintf("cloudflared found: %s", path),
+	}
+}
+
+// SystemChecks returns all system-level health checks in order.
+func SystemChecks() []Check {
+	plistPath := platform.PlistPath()
+
+	caCertPath, _ := certmanager.CACertPath()
+	caKeyPath, _ := certmanager.CAKeyPath()
+	registryPath, _ := registry.DefaultPath()
+
+	return []Check{
+		{
+			Name:     "Resolver file",
+			Category: "DNS",
+			Run: func() *Result {
+				return checkFileExists(platform.ResolverPath, "Resolver file", "Run: outport system start")
+			},
+		},
+		{
+			Name:     "Resolver content",
+			Category: "DNS",
+			Run: func() *Result {
+				return checkResolverContent(platform.ResolverPath, platform.ResolverContent)
+			},
+		},
+		{
+			Name:     "Plist installed",
+			Category: "Daemon",
+			Run: func() *Result {
+				return checkFileExists(plistPath, "Plist installed", "Run: outport system start")
+			},
+		},
+		{
+			Name:     "Plist binary",
+			Category: "Daemon",
+			Run: func() *Result {
+				return checkPlistBinary(plistPath)
+			},
+		},
+		{
+			Name:     "Agent loaded",
+			Category: "Daemon",
+			Run: func() *Result {
+				return checkAgentLoaded()
+			},
+		},
+		{
+			Name:     "HTTP proxy",
+			Category: "Daemon",
+			Run: func() *Result {
+				return checkPortUp(80, "HTTP proxy", "Run: outport system start")
+			},
+		},
+		{
+			Name:     "HTTPS proxy",
+			Category: "Daemon",
+			Run: func() *Result {
+				return checkPortUp(443, "HTTPS proxy", "Run: outport system start")
+			},
+		},
+		{
+			Name:     "CA cert exists",
+			Category: "TLS",
+			Run: func() *Result {
+				return checkFileExists(caCertPath, "CA cert exists", "Run: outport system start")
+			},
+		},
+		{
+			Name:     "CA key exists",
+			Category: "TLS",
+			Run: func() *Result {
+				return checkFileExists(caKeyPath, "CA key exists", "Run: outport system start")
+			},
+		},
+		{
+			Name:     "CA expiry",
+			Category: "TLS",
+			Run: func() *Result {
+				return checkCertExpiry(caCertPath)
+			},
+		},
+		{
+			Name:     "CA trusted",
+			Category: "TLS",
+			Run: func() *Result {
+				return checkCATrusted(caCertPath)
+			},
+		},
+		{
+			Name:     "Registry valid",
+			Category: "Registry",
+			Run: func() *Result {
+				return checkRegistryValid(registryPath)
+			},
+		},
+		{
+			Name:     "cloudflared",
+			Category: "Tools",
+			Run: func() *Result {
+				return checkCloudflared()
+			},
+		},
+	}
+}

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -350,6 +350,13 @@ func SystemChecks() []Check {
 			},
 		},
 		{
+			Name:     "DNS resolving *.test",
+			Category: "System",
+			Run: func() *Result {
+				return checkDNSResolving("127.0.0.1:15353")
+			},
+		},
+		{
 			Name:     "HTTP proxy",
 			Category: "Daemon",
 			Run: func() *Result {

--- a/internal/doctor/checks.go
+++ b/internal/doctor/checks.go
@@ -137,8 +137,8 @@ func checkPlistBinary(plistPath string) *Result {
 		return &Result{
 			Name:    "Plist binary",
 			Status:  Fail,
-			Message: fmt.Sprintf("binary not found: %s", binPath),
-			Fix:     "Reinstall outport and run: outport system start",
+			Message: fmt.Sprintf("daemon plist references missing binary: %s", binPath),
+			Fix:     "Run: outport system restart",
 		}
 	}
 
@@ -315,10 +315,10 @@ func SystemChecks() []Check {
 
 	return []Check{
 		{
-			Name:     "Resolver file",
+			Name:     "DNS resolver",
 			Category: "DNS",
 			Run: func() *Result {
-				return checkFileExists(platform.ResolverPath, "Resolver file", "Run: outport system start")
+				return checkFileExists(platform.ResolverPath, "DNS resolver", "Run: outport system start")
 			},
 		},
 		{
@@ -329,10 +329,17 @@ func SystemChecks() []Check {
 			},
 		},
 		{
-			Name:     "Plist installed",
+			Name:     "DNS resolving *.test",
+			Category: "DNS",
+			Run: func() *Result {
+				return checkDNSResolving("127.0.0.1:15353")
+			},
+		},
+		{
+			Name:     "LaunchAgent plist",
 			Category: "Daemon",
 			Run: func() *Result {
-				return checkFileExists(plistPath, "Plist installed", "Run: outport system start")
+				return checkFileExists(plistPath, "LaunchAgent plist", "Run: outport system start")
 			},
 		},
 		{
@@ -350,13 +357,6 @@ func SystemChecks() []Check {
 			},
 		},
 		{
-			Name:     "DNS resolving *.test",
-			Category: "System",
-			Run: func() *Result {
-				return checkDNSResolving("127.0.0.1:15353")
-			},
-		},
-		{
 			Name:     "HTTP proxy",
 			Category: "Daemon",
 			Run: func() *Result {
@@ -371,17 +371,17 @@ func SystemChecks() []Check {
 			},
 		},
 		{
-			Name:     "CA cert exists",
+			Name:     "CA certificate",
 			Category: "TLS",
 			Run: func() *Result {
-				return checkFileExists(caCertPath, "CA cert exists", "Run: outport system start")
+				return checkFileExists(caCertPath, "CA certificate", "Run: outport system start")
 			},
 		},
 		{
-			Name:     "CA key exists",
+			Name:     "CA private key",
 			Category: "TLS",
 			Run: func() *Result {
-				return checkFileExists(caKeyPath, "CA key exists", "Run: outport system start")
+				return checkFileExists(caKeyPath, "CA private key", "Run: outport system start")
 			},
 		},
 		{

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -1,0 +1,162 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckResolverContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test")
+
+	// Missing file
+	res := checkResolverContent(path, "nameserver 127.0.0.1\nport 15353\n")
+	if res.Status != Fail {
+		t.Errorf("expected Fail for missing file, got %v", res.Status)
+	}
+
+	// Wrong content
+	_ = os.WriteFile(path, []byte("wrong"), 0644)
+	res = checkResolverContent(path, "nameserver 127.0.0.1\nport 15353\n")
+	if res.Status != Fail {
+		t.Errorf("expected Fail for wrong content, got %v", res.Status)
+	}
+
+	// Correct content
+	_ = os.WriteFile(path, []byte("nameserver 127.0.0.1\nport 15353\n"), 0644)
+	res = checkResolverContent(path, "nameserver 127.0.0.1\nport 15353\n")
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v", res.Status)
+	}
+}
+
+func TestCheckFileExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "exists")
+
+	res := checkFileExists(path, "test file", "fix it")
+	if res.Status != Fail {
+		t.Errorf("expected Fail, got %v", res.Status)
+	}
+
+	_ = os.WriteFile(path, []byte("x"), 0644)
+	res = checkFileExists(path, "test file", "fix it")
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v", res.Status)
+	}
+}
+
+func TestCheckPlistBinary(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "test.plist")
+	binaryPath := filepath.Join(dir, "outport")
+
+	// Realistic plist matching platform.GeneratePlist() structure
+	plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.outport.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>` + binaryPath + `</string>
+        <string>daemon</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>Sockets</key>
+    <dict>
+        <key>HTTPSocket</key>
+        <dict>
+            <key>SockNodeName</key>
+            <string>127.0.0.1</string>
+            <key>SockServiceName</key>
+            <string>80</string>
+        </dict>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/outport-daemon.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/outport-daemon.log</string>
+</dict>
+</plist>`
+	_ = os.WriteFile(plistPath, []byte(plist), 0644)
+	_ = os.WriteFile(binaryPath, []byte("binary"), 0755)
+
+	res := checkPlistBinary(plistPath)
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v: %s", res.Status, res.Message)
+	}
+
+	// Binary doesn't exist
+	os.Remove(binaryPath)
+	res = checkPlistBinary(plistPath)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for missing binary, got %v", res.Status)
+	}
+
+	// Malformed plist
+	_ = os.WriteFile(plistPath, []byte("not xml"), 0644)
+	res = checkPlistBinary(plistPath)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for malformed plist, got %v", res.Status)
+	}
+}
+
+func TestParsePlistBinaryPath(t *testing.T) {
+	minimal := []byte(`<?xml version="1.0"?><plist><dict><key>ProgramArguments</key><array><string>/usr/local/bin/outport</string><string>daemon</string></array></dict></plist>`)
+	if got := parsePlistBinaryPath(minimal); got != "/usr/local/bin/outport" {
+		t.Errorf("expected /usr/local/bin/outport, got %q", got)
+	}
+
+	if got := parsePlistBinaryPath([]byte("")); got != "" {
+		t.Errorf("expected empty string for empty input, got %q", got)
+	}
+
+	noProg := []byte(`<?xml version="1.0"?><plist><dict><key>Label</key><string>test</string></dict></plist>`)
+	if got := parsePlistBinaryPath(noProg); got != "" {
+		t.Errorf("expected empty string for missing ProgramArguments, got %q", got)
+	}
+}
+
+func TestCheckCertExpiry(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-cert.pem")
+
+	res := checkCertExpiry(certPath)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for missing cert, got %v", res.Status)
+	}
+
+	_ = os.WriteFile(certPath, []byte("not a cert"), 0644)
+	res = checkCertExpiry(certPath)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for invalid cert, got %v", res.Status)
+	}
+}
+
+func TestCheckRegistryValid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+
+	res := checkRegistryValid(path)
+	if res.Status != Warn {
+		t.Errorf("expected Warn for missing registry, got %v", res.Status)
+	}
+
+	_ = os.WriteFile(path, []byte(`{"projects":{}}`), 0644)
+	res = checkRegistryValid(path)
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v", res.Status)
+	}
+
+	_ = os.WriteFile(path, []byte(`{broken`), 0644)
+	res = checkRegistryValid(path)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for corrupt registry, got %v", res.Status)
+	}
+}

--- a/internal/doctor/dns.go
+++ b/internal/doctor/dns.go
@@ -1,0 +1,45 @@
+package doctor
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// checkDNSResolving sends a UDP query to the given resolver address for
+// "outport-check.test" and verifies it returns 127.0.0.1.
+func checkDNSResolving(resolverAddr string) *Result {
+	name := "DNS resolving *.test"
+
+	c := new(dns.Client)
+	c.Timeout = 2 * time.Second
+
+	m := new(dns.Msg)
+	m.SetQuestion("outport-check.test.", dns.TypeA)
+
+	r, _, err := c.Exchange(m, resolverAddr)
+	if err != nil {
+		return &Result{
+			Name:    name,
+			Status:  Fail,
+			Message: fmt.Sprintf("DNS query failed: %v", err),
+			Fix:     "Run: outport system restart",
+		}
+	}
+
+	if len(r.Answer) == 0 {
+		return &Result{Name: name, Status: Fail, Message: "DNS query returned no answers", Fix: "Run: outport system restart"}
+	}
+
+	for _, ans := range r.Answer {
+		if a, ok := ans.(*dns.A); ok {
+			if a.A.Equal(net.IPv4(127, 0, 0, 1)) {
+				return &Result{Name: name, Status: Pass, Message: "DNS resolving *.test → 127.0.0.1"}
+			}
+		}
+	}
+
+	return &Result{Name: name, Status: Fail, Message: "DNS query did not return 127.0.0.1", Fix: "Run: outport system restart"}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,71 @@
+package doctor
+
+// Status represents the outcome of a health check.
+type Status int
+
+const (
+	Pass Status = iota
+	Warn
+	Fail
+)
+
+// String returns the lowercase status label for JSON output.
+func (s Status) String() string {
+	switch s {
+	case Pass:
+		return "pass"
+	case Warn:
+		return "warn"
+	case Fail:
+		return "fail"
+	default:
+		return "unknown"
+	}
+}
+
+// Check is a single diagnostic check.
+type Check struct {
+	Name     string
+	Category string
+	Run      func() *Result
+}
+
+// Result is the outcome of running a Check.
+type Result struct {
+	Name     string
+	Category string
+	Status   Status
+	Message  string
+	Fix      string
+}
+
+// Runner collects and executes checks sequentially.
+type Runner struct {
+	checks []Check
+}
+
+// Add appends a check to the runner.
+func (r *Runner) Add(c Check) {
+	r.checks = append(r.checks, c)
+}
+
+// Run executes all checks in order and returns the results.
+func (r *Runner) Run() []Result {
+	results := make([]Result, 0, len(r.checks))
+	for _, c := range r.checks {
+		res := c.Run()
+		res.Category = c.Category
+		results = append(results, *res)
+	}
+	return results
+}
+
+// HasFailures returns true if any result has Fail status.
+func HasFailures(results []Result) bool {
+	for _, r := range results {
+		if r.Status == Fail {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,98 @@
+package doctor
+
+import "testing"
+
+func TestRunnerAllPass(t *testing.T) {
+	r := &Runner{}
+	r.Add(Check{
+		Name:     "check1",
+		Category: "Test",
+		Run: func() *Result {
+			return &Result{Name: "check1", Status: Pass, Message: "ok"}
+		},
+	})
+	r.Add(Check{
+		Name:     "check2",
+		Category: "Test",
+		Run: func() *Result {
+			return &Result{Name: "check2", Status: Pass, Message: "ok"}
+		},
+	})
+	results := r.Run()
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if HasFailures(results) {
+		t.Error("expected no failures")
+	}
+}
+
+func TestRunnerWithWarn(t *testing.T) {
+	r := &Runner{}
+	r.Add(Check{
+		Name:     "warn-check",
+		Category: "Test",
+		Run: func() *Result {
+			return &Result{Name: "warn-check", Status: Warn, Message: "warning", Fix: "do something"}
+		},
+	})
+	results := r.Run()
+	if results[0].Status != Warn {
+		t.Errorf("expected Warn, got %v", results[0].Status)
+	}
+	if HasFailures(results) {
+		t.Error("warnings should not count as failures")
+	}
+}
+
+func TestRunnerWithFail(t *testing.T) {
+	r := &Runner{}
+	r.Add(Check{
+		Name:     "fail-check",
+		Category: "Test",
+		Run: func() *Result {
+			return &Result{Name: "fail-check", Status: Fail, Message: "broken", Fix: "fix it"}
+		},
+	})
+	results := r.Run()
+	if results[0].Status != Fail {
+		t.Errorf("expected Fail, got %v", results[0].Status)
+	}
+	if !HasFailures(results) {
+		t.Error("expected failures")
+	}
+}
+
+func TestRunnerMixed(t *testing.T) {
+	r := &Runner{}
+	r.Add(Check{Name: "a", Category: "Cat1", Run: func() *Result {
+		return &Result{Name: "a", Status: Pass, Message: "ok"}
+	}})
+	r.Add(Check{Name: "b", Category: "Cat1", Run: func() *Result {
+		return &Result{Name: "b", Status: Warn, Message: "meh", Fix: "try this"}
+	}})
+	r.Add(Check{Name: "c", Category: "Cat2", Run: func() *Result {
+		return &Result{Name: "c", Status: Fail, Message: "bad", Fix: "fix it"}
+	}})
+	results := r.Run()
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	if results[0].Name != "a" || results[1].Name != "b" || results[2].Name != "c" {
+		t.Error("results should preserve insertion order")
+	}
+	if !HasFailures(results) {
+		t.Error("expected failures due to fail check")
+	}
+}
+
+func TestRunnerEmpty(t *testing.T) {
+	r := &Runner{}
+	results := r.Run()
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+	if HasFailures(results) {
+		t.Error("empty results should not have failures")
+	}
+}

--- a/internal/doctor/project.go
+++ b/internal/doctor/project.go
@@ -1,0 +1,111 @@
+package doctor
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/outport-app/outport/internal/config"
+	"github.com/outport-app/outport/internal/portcheck"
+	"github.com/outport-app/outport/internal/registry"
+)
+
+// checkConfigValid attempts to load and validate the .outport.yml in dir.
+func checkConfigValid(dir string) *Result {
+	name := ".outport.yml valid"
+	_, err := config.Load(dir)
+	if err != nil {
+		return &Result{Name: name, Status: Fail, Message: fmt.Sprintf(".outport.yml: %v", err)}
+	}
+	return &Result{Name: name, Status: Pass, Message: ".outport.yml valid"}
+}
+
+// checkProjectRegistered checks if the current directory is registered in the registry.
+func checkProjectRegistered(regPath, dir string) *Result {
+	name := "Project registered"
+	reg, err := registry.Load(regPath)
+	if err != nil {
+		return &Result{Name: name, Status: Fail, Message: fmt.Sprintf("could not load registry: %v", err)}
+	}
+	key, _, found := reg.FindByDir(dir)
+	if !found {
+		return &Result{Name: name, Status: Fail, Message: "project not registered", Fix: "Run: outport up"}
+	}
+	return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("Project registered (%s)", key)}
+}
+
+// checkPortAvailable checks if an allocated port is in use.
+// Returns Warn (not Fail) because the service itself may be running.
+func checkPortAvailable(port int, serviceName string) *Result {
+	name := fmt.Sprintf("Port %d (%s)", port, serviceName)
+	if portcheck.IsUp(port) {
+		return &Result{Name: name, Status: Warn, Message: fmt.Sprintf("Port %d (%s) is in use", port, serviceName)}
+	}
+	return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("Port %d (%s) available", port, serviceName)}
+}
+
+// ProjectChecks returns project-level health checks for the given directory.
+// cfg may be nil if config loading failed (in which case only the config check is returned).
+// regPath is the path to registry.json.
+func ProjectChecks(dir string, cfg *config.Config, configErr error, regPath string) []Check {
+	category := "Project"
+	if cfg != nil {
+		category = fmt.Sprintf("Project (%s)", cfg.Name)
+	}
+
+	var checks []Check
+
+	// Config validity check
+	if configErr != nil {
+		checks = append(checks, Check{
+			Name:     ".outport.yml valid",
+			Category: category,
+			Run: func() *Result {
+				return &Result{Name: ".outport.yml valid", Status: Fail, Message: fmt.Sprintf(".outport.yml: %v", configErr)}
+			},
+		})
+		return checks // Skip remaining project checks
+	}
+
+	checks = append(checks, Check{
+		Name:     ".outport.yml valid",
+		Category: category,
+		Run: func() *Result {
+			return &Result{Name: ".outport.yml valid", Status: Pass, Message: ".outport.yml valid"}
+		},
+	})
+
+	// Registration check
+	checks = append(checks, Check{
+		Name:     "Project registered",
+		Category: category,
+		Run: func() *Result {
+			return checkProjectRegistered(regPath, dir)
+		},
+	})
+
+	// Port checks — load registry to get allocated ports
+	reg, err := registry.Load(regPath)
+	if err == nil {
+		if _, alloc, found := reg.FindByDir(dir); found {
+			serviceNames := make([]string, 0, len(alloc.Ports))
+			for name := range alloc.Ports {
+				serviceNames = append(serviceNames, name)
+			}
+			sort.Strings(serviceNames)
+			for _, svcName := range serviceNames {
+				port := alloc.Ports[svcName]
+				svc := svcName // capture for closure
+				p := port
+				checks = append(checks, Check{
+					Name:     fmt.Sprintf("Port %d (%s)", p, svc),
+					Category: category,
+					Run: func() *Result {
+						return checkPortAvailable(p, svc)
+					},
+				})
+			}
+		}
+	}
+
+	return checks
+}

--- a/internal/doctor/project.go
+++ b/internal/doctor/project.go
@@ -9,14 +9,14 @@ import (
 	"github.com/outport-app/outport/internal/registry"
 )
 
-// checkPortAvailable checks if an allocated port is in use.
-// Returns Warn (not Fail) because the service itself may be running.
-func checkPortAvailable(port int, serviceName string) *Result {
+// checkPortStatus reports whether an allocated port is in use (service running)
+// or not (service stopped). Both are Pass — this is informational, not a problem.
+func checkPortStatus(port int, serviceName string) *Result {
 	name := fmt.Sprintf("Port %d (%s)", port, serviceName)
 	if portcheck.IsUp(port) {
-		return &Result{Name: name, Status: Warn, Message: fmt.Sprintf("Port %d (%s) is in use", port, serviceName)}
+		return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("Port %d (%s) in use", port, serviceName)}
 	}
-	return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("Port %d (%s) available", port, serviceName)}
+	return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("Port %d (%s) not running", port, serviceName)}
 }
 
 // ProjectChecks returns project-level health checks for the given directory.
@@ -83,7 +83,7 @@ func ProjectChecks(dir string, cfg *config.Config, configErr error, regPath stri
 				Name:     fmt.Sprintf("Port %d (%s)", port, svcName),
 				Category: category,
 				Run: func() *Result {
-					return checkPortAvailable(port, svcName)
+					return checkPortStatus(port, svcName)
 				},
 			})
 		}

--- a/internal/doctor/project.go
+++ b/internal/doctor/project.go
@@ -9,30 +9,6 @@ import (
 	"github.com/outport-app/outport/internal/registry"
 )
 
-// checkConfigValid attempts to load and validate the .outport.yml in dir.
-func checkConfigValid(dir string) *Result {
-	name := ".outport.yml valid"
-	_, err := config.Load(dir)
-	if err != nil {
-		return &Result{Name: name, Status: Fail, Message: fmt.Sprintf(".outport.yml: %v", err)}
-	}
-	return &Result{Name: name, Status: Pass, Message: ".outport.yml valid"}
-}
-
-// checkProjectRegistered checks if the current directory is registered in the registry.
-func checkProjectRegistered(regPath, dir string) *Result {
-	name := "Project registered"
-	reg, err := registry.Load(regPath)
-	if err != nil {
-		return &Result{Name: name, Status: Fail, Message: fmt.Sprintf("could not load registry: %v", err)}
-	}
-	key, _, found := reg.FindByDir(dir)
-	if !found {
-		return &Result{Name: name, Status: Fail, Message: "project not registered", Fix: "Run: outport up"}
-	}
-	return &Result{Name: name, Status: Pass, Message: fmt.Sprintf("Project registered (%s)", key)}
-}
-
 // checkPortAvailable checks if an allocated port is in use.
 // Returns Warn (not Fail) because the service itself may be running.
 func checkPortAvailable(port int, serviceName string) *Result {
@@ -74,36 +50,42 @@ func ProjectChecks(dir string, cfg *config.Config, configErr error, regPath stri
 		},
 	})
 
+	// Load registry once for both registration check and port checks
+	reg, err := registry.Load(regPath)
+	if err != nil {
+		return checks
+	}
+
+	key, alloc, found := reg.FindByDir(dir)
+
 	// Registration check
 	checks = append(checks, Check{
 		Name:     "Project registered",
 		Category: category,
 		Run: func() *Result {
-			return checkProjectRegistered(regPath, dir)
+			if !found {
+				return &Result{Name: "Project registered", Status: Fail, Message: "project not registered", Fix: "Run: outport up"}
+			}
+			return &Result{Name: "Project registered", Status: Pass, Message: fmt.Sprintf("Project registered (%s)", key)}
 		},
 	})
 
-	// Port checks — load registry to get allocated ports
-	reg, err := registry.Load(regPath)
-	if err == nil {
-		if _, alloc, found := reg.FindByDir(dir); found {
-			serviceNames := make([]string, 0, len(alloc.Ports))
-			for name := range alloc.Ports {
-				serviceNames = append(serviceNames, name)
-			}
-			sort.Strings(serviceNames)
-			for _, svcName := range serviceNames {
-				port := alloc.Ports[svcName]
-				svc := svcName // capture for closure
-				p := port
-				checks = append(checks, Check{
-					Name:     fmt.Sprintf("Port %d (%s)", p, svc),
-					Category: category,
-					Run: func() *Result {
-						return checkPortAvailable(p, svc)
-					},
-				})
-			}
+	// Port checks
+	if found {
+		serviceNames := make([]string, 0, len(alloc.Ports))
+		for name := range alloc.Ports {
+			serviceNames = append(serviceNames, name)
+		}
+		sort.Strings(serviceNames)
+		for _, svcName := range serviceNames {
+			port := alloc.Ports[svcName]
+			checks = append(checks, Check{
+				Name:     fmt.Sprintf("Port %d (%s)", port, svcName),
+				Category: category,
+				Run: func() *Result {
+					return checkPortAvailable(port, svcName)
+				},
+			})
 		}
 	}
 

--- a/internal/doctor/project_test.go
+++ b/internal/doctor/project_test.go
@@ -47,9 +47,6 @@ func TestProjectChecksInvalidConfig(t *testing.T) {
 	regPath := filepath.Join(dir, "registry.json")
 	_ = os.WriteFile(regPath, []byte(`{"projects":{}}`), 0644)
 
-	configErr := config.Load  // trigger an error by passing nil cfg
-	_ = configErr
-
 	// Simulate a config error
 	checks := ProjectChecks(dir, nil, os.ErrNotExist, regPath)
 	if len(checks) != 1 {

--- a/internal/doctor/project_test.go
+++ b/internal/doctor/project_test.go
@@ -1,0 +1,49 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckConfigValid(t *testing.T) {
+	dir := t.TempDir()
+
+	// Valid config
+	cfg := `name: myapp
+services:
+  web:
+    env_var: PORT
+`
+	_ = os.WriteFile(filepath.Join(dir, ".outport.yml"), []byte(cfg), 0644)
+	res := checkConfigValid(dir)
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v: %s", res.Status, res.Message)
+	}
+
+	// Invalid config (missing name)
+	_ = os.WriteFile(filepath.Join(dir, ".outport.yml"), []byte("services:\n  web:\n    env_var: PORT\n"), 0644)
+	res = checkConfigValid(dir)
+	if res.Status != Fail {
+		t.Errorf("expected Fail, got %v", res.Status)
+	}
+}
+
+func TestCheckProjectRegistered(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+
+	// Empty registry
+	_ = os.WriteFile(regPath, []byte(`{"projects":{}}`), 0644)
+	res := checkProjectRegistered(regPath, dir)
+	if res.Status != Fail {
+		t.Errorf("expected Fail for unregistered project, got %v", res.Status)
+	}
+
+	// Registered
+	_ = os.WriteFile(regPath, []byte(`{"projects":{"myapp/main":{"project_dir":"`+dir+`","ports":{"web":3000}}}}`), 0644)
+	res = checkProjectRegistered(regPath, dir)
+	if res.Status != Pass {
+		t.Errorf("expected Pass, got %v: %s", res.Status, res.Message)
+	}
+}

--- a/internal/doctor/project_test.go
+++ b/internal/doctor/project_test.go
@@ -4,46 +4,90 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/outport-app/outport/internal/config"
 )
 
-func TestCheckConfigValid(t *testing.T) {
+func TestProjectChecksValidConfig(t *testing.T) {
 	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+	_ = os.WriteFile(regPath, []byte(`{"projects":{}}`), 0644)
 
-	// Valid config
-	cfg := `name: myapp
+	cfgYAML := `name: myapp
 services:
   web:
     env_var: PORT
 `
-	_ = os.WriteFile(filepath.Join(dir, ".outport.yml"), []byte(cfg), 0644)
-	res := checkConfigValid(dir)
-	if res.Status != Pass {
-		t.Errorf("expected Pass, got %v: %s", res.Status, res.Message)
+	_ = os.WriteFile(filepath.Join(dir, ".outport.yml"), []byte(cfgYAML), 0644)
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected config error: %v", err)
 	}
 
-	// Invalid config (missing name)
-	_ = os.WriteFile(filepath.Join(dir, ".outport.yml"), []byte("services:\n  web:\n    env_var: PORT\n"), 0644)
-	res = checkConfigValid(dir)
+	checks := ProjectChecks(dir, cfg, nil, regPath)
+	if len(checks) < 2 {
+		t.Fatalf("expected at least 2 checks (config + registered), got %d", len(checks))
+	}
+
+	// Config check should pass
+	res := checks[0].Run()
+	if res.Status != Pass {
+		t.Errorf("expected config check Pass, got %v: %s", res.Status, res.Message)
+	}
+
+	// Registration check should fail (project not in registry)
+	res = checks[1].Run()
 	if res.Status != Fail {
-		t.Errorf("expected Fail, got %v", res.Status)
+		t.Errorf("expected registration Fail for unregistered project, got %v", res.Status)
 	}
 }
 
-func TestCheckProjectRegistered(t *testing.T) {
+func TestProjectChecksInvalidConfig(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+	_ = os.WriteFile(regPath, []byte(`{"projects":{}}`), 0644)
+
+	configErr := config.Load  // trigger an error by passing nil cfg
+	_ = configErr
+
+	// Simulate a config error
+	checks := ProjectChecks(dir, nil, os.ErrNotExist, regPath)
+	if len(checks) != 1 {
+		t.Fatalf("expected 1 check (config only), got %d", len(checks))
+	}
+	res := checks[0].Run()
+	if res.Status != Fail {
+		t.Errorf("expected config check Fail, got %v", res.Status)
+	}
+}
+
+func TestProjectChecksRegistered(t *testing.T) {
 	dir := t.TempDir()
 	regPath := filepath.Join(dir, "registry.json")
 
-	// Empty registry
-	_ = os.WriteFile(regPath, []byte(`{"projects":{}}`), 0644)
-	res := checkProjectRegistered(regPath, dir)
-	if res.Status != Fail {
-		t.Errorf("expected Fail for unregistered project, got %v", res.Status)
+	// Register the project
+	_ = os.WriteFile(regPath, []byte(`{"projects":{"myapp/main":{"project_dir":"`+dir+`","ports":{"web":3000}}}}`), 0644)
+
+	cfgYAML := `name: myapp
+services:
+  web:
+    env_var: PORT
+`
+	_ = os.WriteFile(filepath.Join(dir, ".outport.yml"), []byte(cfgYAML), 0644)
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected config error: %v", err)
 	}
 
-	// Registered
-	_ = os.WriteFile(regPath, []byte(`{"projects":{"myapp/main":{"project_dir":"`+dir+`","ports":{"web":3000}}}}`), 0644)
-	res = checkProjectRegistered(regPath, dir)
+	checks := ProjectChecks(dir, cfg, nil, regPath)
+	// Should have: config valid + project registered + port check for web
+	if len(checks) != 3 {
+		t.Fatalf("expected 3 checks, got %d", len(checks))
+	}
+
+	// Registration should pass
+	res := checks[1].Run()
 	if res.Status != Pass {
-		t.Errorf("expected Pass, got %v: %s", res.Status, res.Message)
+		t.Errorf("expected registration Pass, got %v: %s", res.Status, res.Message)
 	}
 }

--- a/internal/platform/darwin.go
+++ b/internal/platform/darwin.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	resolverPath = "/etc/resolver/test"
-	plistName    = "dev.outport.daemon.plist"
-	plistLabel   = "dev.outport.daemon"
+	ResolverPath    = "/etc/resolver/test"
+	ResolverContent = "nameserver 127.0.0.1\nport 15353\n"
+	plistName       = "dev.outport.daemon.plist"
+	plistLabel      = "dev.outport.daemon"
 )
 
-func plistPath() string {
+func PlistPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
@@ -24,28 +25,26 @@ func plistPath() string {
 }
 
 func isResolverInstalled() bool {
-	_, err := os.Stat(resolverPath)
+	_, err := os.Stat(ResolverPath)
 	return err == nil
 }
 
 func isPlistInstalled() bool {
-	_, err := os.Stat(plistPath())
+	_, err := os.Stat(PlistPath())
 	return err == nil
 }
 
 // WriteResolverFile creates /etc/resolver/test pointing to the local DNS server.
 // Requires sudo — the caller should inform the user that a password prompt may appear.
 func WriteResolverFile() error {
-	content := "nameserver 127.0.0.1\nport 15353\n"
-
 	// Skip if file already has the correct content.
-	existing, err := os.ReadFile(resolverPath)
-	if err == nil && string(existing) == content {
+	existing, err := os.ReadFile(ResolverPath)
+	if err == nil && string(existing) == ResolverContent {
 		return nil
 	}
 
 	// Ensure /etc/resolver/ exists (not present by default on fresh macOS installs).
-	resolverDir := filepath.Dir(resolverPath)
+	resolverDir := filepath.Dir(ResolverPath)
 	mkdirCmd := exec.Command("sudo", "mkdir", "-p", resolverDir)
 	mkdirCmd.Stderr = os.Stderr
 	if err := mkdirCmd.Run(); err != nil {
@@ -54,12 +53,12 @@ func WriteResolverFile() error {
 
 	// Write to a temp file, then sudo cp into place.
 	tmpFile := fmt.Sprintf("/tmp/outport-resolver-%d", os.Getpid())
-	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(ResolverContent), 0644); err != nil {
 		return fmt.Errorf("writing temp resolver file: %w", err)
 	}
 	defer os.Remove(tmpFile)
 
-	cpCmd := exec.Command("sudo", "cp", tmpFile, resolverPath)
+	cpCmd := exec.Command("sudo", "cp", tmpFile, ResolverPath)
 	cpCmd.Stderr = os.Stderr
 	if err := cpCmd.Run(); err != nil {
 		return fmt.Errorf("copying resolver file: %w", err)
@@ -70,7 +69,7 @@ func WriteResolverFile() error {
 // RemoveResolverFile removes /etc/resolver/test.
 // Requires sudo.
 func RemoveResolverFile() error {
-	cmd := exec.Command("sudo", "rm", "-f", resolverPath)
+	cmd := exec.Command("sudo", "rm", "-f", ResolverPath)
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("removing resolver file: %w", err)
@@ -83,7 +82,7 @@ func RemoveResolverFile() error {
 func WritePlist(outportBinary string) error {
 	content := GeneratePlist(outportBinary)
 
-	path := plistPath()
+	path := PlistPath()
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating LaunchAgents directory: %w", err)
@@ -140,7 +139,7 @@ func GeneratePlist(outportBinary string) string {
 
 // RemovePlist removes the LaunchAgent plist file.
 func RemovePlist() error {
-	path := plistPath()
+	path := PlistPath()
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("removing plist: %w", err)
 	}
@@ -155,7 +154,7 @@ func IsAgentLoaded() bool {
 
 // LoadAgent loads the LaunchAgent via launchctl.
 func LoadAgent() error {
-	cmd := exec.Command("launchctl", "load", plistPath())
+	cmd := exec.Command("launchctl", "load", PlistPath())
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("loading LaunchAgent: %w", err)
@@ -165,7 +164,7 @@ func LoadAgent() error {
 
 // UnloadAgent unloads the LaunchAgent via launchctl.
 func UnloadAgent() error {
-	cmd := exec.Command("launchctl", "unload", plistPath())
+	cmd := exec.Command("launchctl", "unload", PlistPath())
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("unloading LaunchAgent: %w", err)
@@ -197,4 +196,11 @@ func UntrustCA(certPath string) error {
 		return fmt.Errorf("removing CA from trust store: %w", err)
 	}
 	return nil
+}
+
+// IsCATrusted checks if the CA certificate is trusted in the system keychain
+// by running "security verify-cert".
+func IsCATrusted(certPath string) bool {
+	err := exec.Command("security", "verify-cert", "-c", certPath).Run()
+	return err == nil
 }

--- a/internal/platform/darwin_test.go
+++ b/internal/platform/darwin_test.go
@@ -70,14 +70,14 @@ func TestGeneratePlistDualSockets(t *testing.T) {
 }
 
 func TestPlistPath(t *testing.T) {
-	path := plistPath()
+	path := PlistPath()
 	if path == "" {
-		t.Fatal("plistPath() returned empty string")
+		t.Fatal("PlistPath() returned empty string")
 	}
 	if !strings.Contains(path, "Library/LaunchAgents") {
-		t.Errorf("plistPath() = %q, want it to contain Library/LaunchAgents", path)
+		t.Errorf("PlistPath() = %q, want it to contain Library/LaunchAgents", path)
 	}
 	if !strings.HasSuffix(path, plistName) {
-		t.Errorf("plistPath() = %q, want it to end with %s", path, plistName)
+		t.Errorf("PlistPath() = %q, want it to end with %s", path, plistName)
 	}
 }

--- a/internal/platform/other.go
+++ b/internal/platform/other.go
@@ -6,9 +6,15 @@ import "fmt"
 
 var errUnsupported = fmt.Errorf("outport system start is only supported on macOS")
 
+const (
+	ResolverPath    = "/etc/resolver/test"
+	ResolverContent = "nameserver 127.0.0.1\nport 15353\n"
+)
+
 func isResolverInstalled() bool { return false }
 func isPlistInstalled() bool    { return false }
 
+func PlistPath() string                 { return "" }
 func WriteResolverFile() error          { return errUnsupported }
 func RemoveResolverFile() error         { return errUnsupported }
 func WritePlist(_ string) error         { return errUnsupported }
@@ -19,3 +25,4 @@ func UnloadAgent() error                { return errUnsupported }
 func GeneratePlist(_ string) string     { return "" }
 func TrustCA(_ string) error            { return errUnsupported }
 func UntrustCA(_ string) error          { return errUnsupported }
+func IsCATrusted(_ string) bool         { return false }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,9 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		if err != cmd.ErrSilent {
+			fmt.Fprintln(os.Stderr, err)
+		}
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,7 +10,7 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		if err != cmd.ErrSilent {
+		if !errors.Is(err, cmd.ErrSilent) {
 			fmt.Fprintln(os.Stderr, err)
 		}
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- Adds `outport doctor` — a top-level diagnostic command that checks the health of all Outport infrastructure
- Checks DNS resolver, LaunchAgent daemon, CA certificates, registry, and project config
- Reports pass/warn/fail for each check with actionable fix suggestions
- Supports `--json` for machine-readable output
- Exit code 0 if all pass/warn, exit code 1 if any fail

## Test plan

- [x] `just test` passes (13 new doctor tests + all existing)
- [x] `just lint` passes
- [x] `outport doctor` shows styled output with ✓/✗/! indicators
- [x] `outport doctor --json` outputs valid JSON
- [x] Project checks appear when run from a directory with `.outport.yml`
- [x] Project checks absent when no `.outport.yml` found
- [ ] Manual: verify on a machine without `outport system start` to confirm fail suggestions

Closes #35