### PR TITLE
feat: rename `outport ports` to `outport status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ outport setup              One-time system setup
 outport init               Create outport.yml
 outport up [--force]       Allocate ports, write .env
 outport down               Remove ports, clean .env
-outport ports [--computed] Show allocated ports
+outport status [--computed] Show project status
 outport open               Open services in the browser
 outport qr [--tunnel]      QR codes for mobile access
 outport share [service]    Tunnel services to public URLs

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -347,16 +347,16 @@ func TestUp_NoComputed_OmitsFromJSON(t *testing.T) {
 	}
 }
 
-// --- ports ---
+// --- status (project) ---
 
-func TestPorts_ShowsAllocatedPorts(t *testing.T) {
+func TestStatus_ShowsAllocatedPorts(t *testing.T) {
 	setupProject(t, testConfig)
 
 	// First allocate ports
 	executeCmd(t, "up", "--json")
 
 	// Then query them
-	output := executeCmd(t, "ports", "--json")
+	output := executeCmd(t, "status", "--json")
 
 	var result struct {
 		Project  string `json:"project"`
@@ -382,10 +382,10 @@ func TestPorts_ShowsAllocatedPorts(t *testing.T) {
 	}
 }
 
-func TestPorts_NoAllocation(t *testing.T) {
+func TestStatus_NoAllocation(t *testing.T) {
 	setupProject(t, testConfig)
 
-	output := executeCmd(t, "ports")
+	output := executeCmd(t, "status")
 
 	if !bytes.Contains([]byte(output), []byte("No ports allocated")) {
 		t.Errorf("expected 'No ports allocated' message, got:\n%s", output)
@@ -708,11 +708,11 @@ func TestInit_ErrorWhenConfigExists(t *testing.T) {
 	}
 }
 
-func TestPorts_StyledOutput(t *testing.T) {
+func TestStatus_StyledOutput(t *testing.T) {
 	setupProject(t, testConfig)
 	executeCmd(t, "up")
 
-	output := executeCmd(t, "ports")
+	output := executeCmd(t, "status")
 
 	if !bytes.Contains([]byte(output), []byte("testapp")) {
 		t.Errorf("styled output missing project name, got:\n%s", output)
@@ -734,9 +734,9 @@ func TestDown_RemovesFromRegistry(t *testing.T) {
 		t.Errorf("expected 'Done' message, got:\n%s", output)
 	}
 
-	portsOutput := executeCmd(t, "ports")
-	if !bytes.Contains([]byte(portsOutput), []byte("No ports allocated")) {
-		t.Errorf("expected no ports after unregister, got:\n%s", portsOutput)
+	statusOutput := executeCmd(t, "status")
+	if !bytes.Contains([]byte(statusOutput), []byte("No ports allocated")) {
+		t.Errorf("expected no ports after unregister, got:\n%s", statusOutput)
 	}
 }
 

--- a/cmd/cmdutil_test.go
+++ b/cmd/cmdutil_test.go
@@ -37,7 +37,7 @@ func TestAllCommandsHaveArgsValidation(t *testing.T) {
 // accept arguments return a FlagError when given unexpected args.
 func TestNoArgsCommandsRejectArguments(t *testing.T) {
 	noArgsCmds := []string{
-		"up", "down", "init", "ports", "promote",
+		"up", "down", "init", "status", "promote",
 	}
 
 	for _, name := range noArgsCmds {

--- a/cmd/project_status.go
+++ b/cmd/project_status.go
@@ -13,24 +13,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var portsCheckFlag bool
-var portsComputedFlag bool
+var projectStatusComputedFlag bool
 
-var portsCmd = &cobra.Command{
-	Use:     "ports",
-	Short:   "Show ports for the current project",
+var projectStatusCmd = &cobra.Command{
+	Use:     "status",
+	Short:   "Show status for the current project",
+	Long:    "Shows ports, hostnames, health status, and computed values for the current project. Health checks run by default.",
 	GroupID: "project",
 	Args:    NoArgs,
-	RunE:    runPorts,
+	RunE:    runProjectStatus,
 }
 
 func init() {
-	portsCmd.Flags().BoolVar(&portsCheckFlag, "check", false, "check if ports are accepting connections")
-	portsCmd.Flags().BoolVar(&portsComputedFlag, "computed", false, "show computed values")
-	rootCmd.AddCommand(portsCmd)
+	projectStatusCmd.Flags().BoolVar(&projectStatusComputedFlag, "computed", false, "show computed values")
+	rootCmd.AddCommand(projectStatusCmd)
 }
 
-func runPorts(cmd *cobra.Command, args []string) error {
+func runProjectStatus(cmd *cobra.Command, args []string) error {
 	ctx, err := loadProjectContext()
 	if err != nil {
 		return err
@@ -43,22 +42,20 @@ func runPorts(cmd *cobra.Command, args []string) error {
 	}
 
 	httpsEnabled := certmanager.IsCAInstalled()
+	portStatus := checkPorts(alloc.Ports)
 
 	if jsonFlag {
-		return printPortsJSON(cmd, ctx.Cfg, ctx.Instance, alloc, httpsEnabled)
+		return printProjectStatusJSON(cmd, ctx.Cfg, ctx.Instance, alloc, portStatus, httpsEnabled)
 	}
-	return printPortsStyled(cmd, ctx.Cfg, ctx.Instance, alloc, httpsEnabled)
+	return printProjectStatusStyled(cmd, ctx.Cfg, ctx.Instance, alloc, portStatus, httpsEnabled)
 }
 
-func printPortsJSON(cmd *cobra.Command, cfg *config.Config, instanceName string, alloc registry.Allocation, httpsEnabled bool) error {
+func printProjectStatusJSON(cmd *cobra.Command, cfg *config.Config, instanceName string, alloc registry.Allocation, portStatus map[int]bool, httpsEnabled bool) error {
 	services := buildServiceMap(cfg, alloc.Ports, alloc.Hostnames, alloc.Aliases, httpsEnabled)
 
-	if portsCheckFlag {
-		portStatus := checkPorts(alloc.Ports)
-		for name, s := range services {
-			s.Up = boolPtr(portStatus[s.Port])
-			services[name] = s
-		}
+	for name, s := range services {
+		s.Up = boolPtr(portStatus[s.Port])
+		services[name] = s
 	}
 
 	out := upJSON{
@@ -66,26 +63,20 @@ func printPortsJSON(cmd *cobra.Command, cfg *config.Config, instanceName string,
 		Instance: instanceName,
 		Services: services,
 	}
-	if portsComputedFlag {
+	if projectStatusComputedFlag {
 		out.Computed = buildComputedMap(cfg.Computed, allocation.ResolveComputed(cfg, instanceName, alloc.Ports, alloc.Hostnames, alloc.Aliases, httpsEnabled, nil))
 	}
 	return writeJSON(cmd, out)
 }
 
-func printPortsStyled(cmd *cobra.Command, cfg *config.Config, instanceName string, alloc registry.Allocation, httpsEnabled bool) error {
+func printProjectStatusStyled(cmd *cobra.Command, cfg *config.Config, instanceName string, alloc registry.Allocation, portStatus map[int]bool, httpsEnabled bool) error {
 	w := cmd.OutOrStdout()
 	printHeader(w, cfg.Name, instanceName)
 
 	serviceNames := slices.Sorted(maps.Keys(alloc.Ports))
-
-	var portStatus map[int]bool
-	if portsCheckFlag {
-		portStatus = checkPorts(alloc.Ports)
-	}
-
 	printFlatServices(w, cfg, serviceNames, alloc.Ports, alloc.Hostnames, alloc.Aliases, portStatus, httpsEnabled)
 
-	if portsComputedFlag {
+	if projectStatusComputedFlag {
 		if resolved := allocation.ResolveComputed(cfg, instanceName, alloc.Ports, alloc.Hostnames, alloc.Aliases, httpsEnabled, nil); len(resolved) > 0 {
 			printComputedValues(w, resolved)
 		}

--- a/docker/smoke-test.sh
+++ b/docker/smoke-test.sh
@@ -68,8 +68,8 @@ kill "$APP_PID" 2>/dev/null || true
 wait "$APP_PID" 2>/dev/null || true
 
 echo ""
-echo "=== outport ports ==="
-outport ports
+echo "=== outport status ==="
+outport status
 
 echo ""
 echo "=== Cleanup ==="

--- a/docs/guide/tips.md
+++ b/docs/guide/tips.md
@@ -102,7 +102,7 @@ Outport allocates deterministic ports — the same project, instance, and servic
 - **You used `--force`** — this re-allocates all ports from scratch
 - **Another project claimed your preferred port** — preferred ports are first-come-first-served across all registered projects
 
-Run `outport ports` to see your current allocations and `outport system status` to see all registered projects.
+Run `outport status` to see your current allocations and `outport system status` to see all registered projects.
 
 ### Stale registry entries
 

--- a/docs/guide/work-with-ai.md
+++ b/docs/guide/work-with-ai.md
@@ -48,7 +48,7 @@ The skill covers:
 Every outport command supports `--json` for structured output that agents can parse:
 
 ```bash
-outport ports --json      # current port allocations
+outport status --json     # current port allocations and health
 outport doctor --json     # system health check results
 outport up --json         # allocation results after setup
 ```

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -54,19 +54,17 @@ Removes the managed block from all env files and removes the project/instance fr
 | `--yes`, `-y` | Auto-approve removing env files outside the project directory |
 | `--json` | Output results as JSON |
 
-### `outport ports`
+### `outport status`
 
-Show ports for the current project.
+Show status for the current project — ports, hostnames, health, and URLs. Health checks run by default.
 
 ```bash
-outport ports
-outport ports --check    # check if ports are accepting connections
-outport ports --computed  # include computed values
+outport status
+outport status --computed  # include computed values
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--check` | Check if ports are accepting connections |
 | `--computed` | Show computed values |
 | `--json` | Output results as JSON |
 

--- a/skills/outport/SKILL.md
+++ b/skills/outport/SKILL.md
@@ -20,9 +20,9 @@ outport up --force        # Clear and re-allocate all ports from scratch
 outport down              # Remove ports and clean .env files
 
 # Inspect & diagnose
-outport ports             # Show ports for current project
-outport ports --computed  # Show ports and computed values
-outport ports --json      # Machine-readable output
+outport status            # Show project status (ports, health, URLs)
+outport status --computed # Include computed values
+outport status --json     # Machine-readable output
 outport open              # Open HTTP services in browser
 outport open web          # Open a specific service
 outport share             # Tunnel HTTP services to public URLs
@@ -411,7 +411,7 @@ Add it to `outport.yml` and run `outport up`. Existing allocations
 are preserved — only the new service gets a port.
 
 ### Agent needs to know the project's URLs
-Run `outport ports --json` for structured output with ports and URLs.
+Run `outport status --json` for structured output with ports, health, and URLs.
 
 ### Services moved to different ports than expected
 Check `outport system status` to see all allocations. If another project


### PR DESCRIPTION
## Summary

Closes #80

Renames `outport ports` to `outport status` — the natural "what's going on" command for a project directory. Health checks run by default (no `--check` flag needed). The `--computed` flag remains.

- `outport status` — shows ports, hostnames, health, URLs, aliases
- `outport status --computed` — includes computed values
- `outport status --json` — machine-readable output
- `outport system status` — global view (unchanged)

The `ports` command is removed entirely (no alias). We're pre-1.0 with one user.

## Test plan

- [ ] `just test` passes
- [ ] `just lint` clean
- [ ] `outport status` shows health checks by default
- [ ] `outport status --json` includes `up` field
- [ ] `outport status --computed` shows computed values
- [ ] `outport system status` still works (unchanged)