### PR TITLE
[codex] Allow outport open to target aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ outport down               Remove ports, clean .env
 outport status [--computed] Show project status
 outport ports [--all]      Show ports with live process info
 outport ports kill <target> Kill process on a port
-outport open               Open services in the browser
+outport open [target]      Open services, aliases, or service:alias targets
 outport qr [--tunnel]      QR codes for mobile access
 outport share [service]    Tunnel services to public URLs
 outport rename [old] <new> Rename an instance

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -91,8 +91,21 @@ services:
     env_var: DATABASE_PORT
 `
 
-// executeCmd runs a root command with args and returns captured stdout.
+// executeCmd runs a root command with args and returns captured output,
+// failing the test if the command returns an error.
 func executeCmd(t *testing.T, args ...string) string {
+	t.Helper()
+
+	out, err := executeCmdAllowError(t, args...)
+	if err != nil {
+		t.Fatalf("command %v failed: %v", args, err)
+	}
+	return out
+}
+
+// executeCmdAllowError runs a root command with args and returns captured
+// output along with any error, for tests that assert on failure.
+func executeCmdAllowError(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 
 	buf := new(bytes.Buffer)
@@ -100,11 +113,8 @@ func executeCmd(t *testing.T, args ...string) string {
 	rootCmd.SetErr(buf)
 	rootCmd.SetArgs(args)
 
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("command %v failed: %v", args, err)
-	}
-
-	return buf.String()
+	err := rootCmd.Execute()
+	return buf.String(), err
 }
 
 // --- up ---

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -6,22 +6,25 @@ import (
 	"os/exec"
 	"runtime"
 	"slices"
+	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/steveclarke/outport/internal/certmanager"
 	"github.com/steveclarke/outport/internal/config"
 	"github.com/steveclarke/outport/internal/registry"
 	"github.com/steveclarke/outport/internal/urlutil"
-	"github.com/spf13/cobra"
 )
 
 var openCmd = &cobra.Command{
-	Use:     "open [service]",
+	Use:     "open [target]",
 	Short:   "Open web services in the browser",
-	Long:    "Opens web services for the current project in your default browser. By default, opens all services with a hostname. If the 'open' field is set in outport.yml, only the listed services are opened. Specify a service name to open just that one.",
+	Long:    "Opens web services for the current project in your default browser. By default, opens all services with a hostname. If the 'open' field is set in outport.yml, only the listed services are opened. Specify a service name, alias name, or service:alias target to open just that one.",
 	GroupID: "project",
-	Args:    MaximumArgs(1, "accepts at most one service name"),
+	Args:    MaximumArgs(1, "accepts at most one target"),
 	RunE:    runOpen,
 }
+
+var openBrowserFunc = openBrowser
 
 func init() {
 	rootCmd.AddCommand(openCmd)
@@ -41,7 +44,17 @@ func runOpen(cmd *cobra.Command, args []string) error {
 	httpsEnabled := certmanager.IsCAInstalled()
 
 	if len(args) == 1 {
-		return openService(cmd, ctx.Cfg, alloc, args[0], httpsEnabled)
+		target, err := resolveOpenTarget(ctx.Cfg, alloc, args[0], httpsEnabled)
+		if err != nil {
+			return err
+		}
+		if err := openResolvedTarget(cmd, target); err != nil {
+			return err
+		}
+		if jsonFlag {
+			return printOpenJSON(cmd, []openTarget{target})
+		}
+		return nil
 	}
 
 	// Determine which services to open
@@ -59,19 +72,23 @@ func runOpen(cmd *cobra.Command, args []string) error {
 	}
 
 	opened := 0
+	var targets []openTarget
 	for _, svcName := range serviceNames {
-		svc := ctx.Cfg.Services[svcName]
-		h := svc.Hostname
-		if allocated, ok := alloc.Hostnames[svcName]; ok {
-			h = allocated
-		}
-		url := fmt.Sprintf("%s://%s", urlutil.EffectiveScheme(h, httpsEnabled), h)
-		if err := openBrowser(url); err != nil {
+		target, err := resolveServiceTarget(ctx.Cfg, alloc, svcName, httpsEnabled)
+		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Could not open %s: %v\n", svcName, err)
 			continue
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Opened %s → %s\n", svcName, url)
+		if err := openResolvedTarget(cmd, target); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Could not open %s: %v\n", svcName, err)
+			continue
+		}
 		opened++
+		targets = append(targets, target)
+	}
+
+	if jsonFlag {
+		return printOpenJSON(cmd, targets)
 	}
 
 	if opened == 0 {
@@ -81,32 +98,128 @@ func runOpen(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func openService(cmd *cobra.Command, cfg *config.Config, alloc registry.Allocation, name string, httpsEnabled bool) error {
-	svc, ok := cfg.Services[name]
-	if !ok {
-		return fmt.Errorf("Service %q not found in outport.yml.", name)
+type openTarget struct {
+	Kind     string `json:"kind"`
+	Service  string `json:"service"`
+	Alias    string `json:"alias,omitempty"`
+	Hostname string `json:"hostname"`
+	URL      string `json:"url"`
+	Port     int    `json:"port"`
+}
+
+func resolveOpenTarget(cfg *config.Config, alloc registry.Allocation, name string, httpsEnabled bool) (openTarget, error) {
+	if serviceName, aliasName, ok := strings.Cut(name, ":"); ok {
+		if serviceName == "" || aliasName == "" || strings.Contains(aliasName, ":") {
+			return openTarget{}, fmt.Errorf("Open target %q must use service:alias.", name)
+		}
+		return resolveAliasTarget(cfg, alloc, serviceName, aliasName, httpsEnabled)
 	}
 
-	_, ok = alloc.Ports[name]
+	if _, ok := cfg.Services[name]; ok {
+		return resolveServiceTarget(cfg, alloc, name, httpsEnabled)
+	}
+
+	return resolveBareAliasTarget(cfg, alloc, name, httpsEnabled)
+}
+
+func resolveServiceTarget(cfg *config.Config, alloc registry.Allocation, name string, httpsEnabled bool) (openTarget, error) {
+	svc, ok := cfg.Services[name]
 	if !ok {
-		return fmt.Errorf("No port allocated for %q. Run 'outport up' first.", name)
+		return openTarget{}, fmt.Errorf("Service %q not found in outport.yml.", name)
+	}
+
+	port, ok := alloc.Ports[name]
+	if !ok {
+		return openTarget{}, fmt.Errorf("No port allocated for %q. Run 'outport up' first.", name)
 	}
 
 	if svc.Hostname == "" {
-		return fmt.Errorf("Service %q has no hostname. Add 'hostname' to open it in the browser.", name)
+		return openTarget{}, fmt.Errorf("Service %q has no hostname. Add 'hostname' to open it in the browser.", name)
 	}
 
 	h := svc.Hostname
 	if allocated, hok := alloc.Hostnames[name]; hok {
 		h = allocated
 	}
-	url := fmt.Sprintf("%s://%s", urlutil.EffectiveScheme(h, httpsEnabled), h)
 
-	if err := openBrowser(url); err != nil {
+	return openTarget{
+		Kind:     "service",
+		Service:  name,
+		Hostname: h,
+		URL:      urlutil.ServiceURL(h, port, httpsEnabled),
+		Port:     port,
+	}, nil
+}
+
+func resolveBareAliasTarget(cfg *config.Config, alloc registry.Allocation, aliasName string, httpsEnabled bool) (openTarget, error) {
+	var matches []string
+	for _, svcName := range slices.Sorted(maps.Keys(alloc.Aliases)) {
+		if _, ok := alloc.Aliases[svcName][aliasName]; ok {
+			matches = append(matches, svcName+":"+aliasName)
+		}
+	}
+
+	if len(matches) == 0 {
+		return openTarget{}, fmt.Errorf("Service or alias %q not found in outport.yml.", aliasName)
+	}
+	if len(matches) > 1 {
+		return openTarget{}, fmt.Errorf("alias %q is ambiguous; use one of: %s.", aliasName, strings.Join(matches, ", "))
+	}
+
+	serviceName, _, _ := strings.Cut(matches[0], ":")
+	return resolveAliasTarget(cfg, alloc, serviceName, aliasName, httpsEnabled)
+}
+
+func resolveAliasTarget(cfg *config.Config, alloc registry.Allocation, serviceName, aliasName string, httpsEnabled bool) (openTarget, error) {
+	if _, ok := cfg.Services[serviceName]; !ok {
+		return openTarget{}, fmt.Errorf("Service %q not found in outport.yml.", serviceName)
+	}
+
+	port, ok := alloc.Ports[serviceName]
+	if !ok {
+		return openTarget{}, fmt.Errorf("No port allocated for %q. Run 'outport up' first.", serviceName)
+	}
+
+	hostname, ok := alloc.Aliases[serviceName][aliasName]
+	if !ok {
+		return openTarget{}, fmt.Errorf("Service %q has no alias %q.", serviceName, aliasName)
+	}
+
+	return openTarget{
+		Kind:     "alias",
+		Service:  serviceName,
+		Alias:    aliasName,
+		Hostname: hostname,
+		URL:      urlutil.ServiceURL(hostname, port, httpsEnabled),
+		Port:     port,
+	}, nil
+}
+
+func openResolvedTarget(cmd *cobra.Command, target openTarget) error {
+	if err := openBrowserFunc(target.URL); err != nil {
 		return fmt.Errorf("Could not open browser: %w.", err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Opened %s → %s\n", name, url)
+	if !jsonFlag {
+		fmt.Fprintf(cmd.OutOrStdout(), "Opened %s → %s\n", target.label(), target.URL)
+	}
 	return nil
+}
+
+func (t openTarget) label() string {
+	if t.Kind == "alias" {
+		return t.Service + ":" + t.Alias
+	}
+	return t.Service
+}
+
+func printOpenJSON(cmd *cobra.Command, targets []openTarget) error {
+	out := struct {
+		Opened []openTarget `json:"opened"`
+	}{
+		Opened: targets,
+	}
+	n := len(targets)
+	return writeJSON(cmd, out, fmt.Sprintf("%d %s opened", n, pluralize(n, "target", "targets")))
 }
 
 func openBrowser(url string) error {

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -122,26 +122,29 @@ func resolveOpenTarget(cfg *config.Config, alloc registry.Allocation, name strin
 	return resolveBareAliasTarget(cfg, alloc, name, httpsEnabled)
 }
 
-func resolveServiceTarget(cfg *config.Config, alloc registry.Allocation, name string, httpsEnabled bool) (openTarget, error) {
-	svc, ok := cfg.Services[name]
-	if !ok {
-		return openTarget{}, fmt.Errorf("Service %q not found in outport.yml.", name)
+// servicePort verifies the service exists and has an allocated port.
+func servicePort(cfg *config.Config, alloc registry.Allocation, name string) (int, error) {
+	if _, ok := cfg.Services[name]; !ok {
+		return 0, fmt.Errorf("Service %q not found in outport.yml.", name)
 	}
-
 	port, ok := alloc.Ports[name]
 	if !ok {
-		return openTarget{}, fmt.Errorf("No port allocated for %q. Run 'outport up' first.", name)
+		return 0, fmt.Errorf("No port allocated for %q. Run 'outport up' first.", name)
+	}
+	return port, nil
+}
+
+func resolveServiceTarget(cfg *config.Config, alloc registry.Allocation, name string, httpsEnabled bool) (openTarget, error) {
+	port, err := servicePort(cfg, alloc, name)
+	if err != nil {
+		return openTarget{}, err
 	}
 
-	if svc.Hostname == "" {
+	if cfg.Services[name].Hostname == "" {
 		return openTarget{}, fmt.Errorf("Service %q has no hostname. Add 'hostname' to open it in the browser.", name)
 	}
 
-	h := svc.Hostname
-	if allocated, hok := alloc.Hostnames[name]; hok {
-		h = allocated
-	}
-
+	h := allocHostname(alloc, cfg, name)
 	return openTarget{
 		Kind:     "service",
 		Service:  name,
@@ -171,13 +174,9 @@ func resolveBareAliasTarget(cfg *config.Config, alloc registry.Allocation, alias
 }
 
 func resolveAliasTarget(cfg *config.Config, alloc registry.Allocation, serviceName, aliasName string, httpsEnabled bool) (openTarget, error) {
-	if _, ok := cfg.Services[serviceName]; !ok {
-		return openTarget{}, fmt.Errorf("Service %q not found in outport.yml.", serviceName)
-	}
-
-	port, ok := alloc.Ports[serviceName]
-	if !ok {
-		return openTarget{}, fmt.Errorf("No port allocated for %q. Run 'outport up' first.", serviceName)
+	port, err := servicePort(cfg, alloc, serviceName)
+	if err != nil {
+		return openTarget{}, err
 	}
 
 	hostname, ok := alloc.Aliases[serviceName][aliasName]

--- a/cmd/open_test.go
+++ b/cmd/open_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 )
@@ -53,16 +52,9 @@ func captureOpenBrowser(t *testing.T) *[]string {
 	return &opened
 }
 
-func executeCmdAllowError(t *testing.T, args ...string) (string, error) {
-	t.Helper()
-
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs(args)
-
-	err := rootCmd.Execute()
-	return buf.String(), err
+// openResult mirrors the JSON envelope emitted by printOpenJSON.
+type openResult struct {
+	Opened []openTarget `json:"opened"`
 }
 
 func TestOpen_ServiceNameWinsOverAlias(t *testing.T) {
@@ -79,16 +71,7 @@ func TestOpen_ServiceNameWinsOverAlias(t *testing.T) {
 		t.Fatalf("opened URL = %q, want service hostname", (*opened)[0])
 	}
 
-	var result struct {
-		Opened []struct {
-			Kind     string `json:"kind"`
-			Service  string `json:"service"`
-			Alias    string `json:"alias,omitempty"`
-			Hostname string `json:"hostname"`
-			URL      string `json:"url"`
-			Port     int    `json:"port"`
-		} `json:"opened"`
-	}
+	var result openResult
 	unwrapJSON(t, output, &result)
 
 	if len(result.Opened) != 1 {
@@ -114,15 +97,7 @@ func TestOpen_UniqueAliasName(t *testing.T) {
 		t.Fatalf("opened URL = %q, want alias hostname", (*opened)[0])
 	}
 
-	var result struct {
-		Opened []struct {
-			Kind     string `json:"kind"`
-			Service  string `json:"service"`
-			Alias    string `json:"alias,omitempty"`
-			Hostname string `json:"hostname"`
-			Port     int    `json:"port"`
-		} `json:"opened"`
-	}
+	var result openResult
 	unwrapJSON(t, output, &result)
 
 	if len(result.Opened) != 1 {
@@ -148,15 +123,7 @@ func TestOpen_ExplicitAliasTarget(t *testing.T) {
 		t.Fatalf("opened URL = %q, want explicit alias hostname", (*opened)[0])
 	}
 
-	var result struct {
-		Opened []struct {
-			Kind     string `json:"kind"`
-			Service  string `json:"service"`
-			Alias    string `json:"alias,omitempty"`
-			Hostname string `json:"hostname"`
-			Port     int    `json:"port"`
-		} `json:"opened"`
-	}
+	var result openResult
 	unwrapJSON(t, output, &result)
 
 	if len(result.Opened) != 1 {

--- a/cmd/open_test.go
+++ b/cmd/open_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+const testConfigWithAliases = `name: testapp
+services:
+  web:
+    preferred_port: 3000
+    env_var: PORT
+    hostname: testapp.test
+    aliases:
+      admin: admin.testapp.test
+      worship: worship.testapp.test
+  worship:
+    preferred_port: 3001
+    env_var: WORSHIP_PORT
+    hostname: service-worship.testapp.test
+`
+
+const testConfigWithDuplicateAliasNames = `name: testapp
+services:
+  web:
+    preferred_port: 3000
+    env_var: PORT
+    hostname: testapp.test
+    aliases:
+      admin: admin.testapp.test
+  api:
+    preferred_port: 3001
+    env_var: API_PORT
+    hostname: api.testapp.test
+    aliases:
+      admin: api-admin.testapp.test
+`
+
+func captureOpenBrowser(t *testing.T) *[]string {
+	t.Helper()
+
+	var opened []string
+	old := openBrowserFunc
+	openBrowserFunc = func(url string) error {
+		opened = append(opened, url)
+		return nil
+	}
+	t.Cleanup(func() {
+		openBrowserFunc = old
+	})
+
+	return &opened
+}
+
+func executeCmdAllowError(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args)
+
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+func TestOpen_ServiceNameWinsOverAlias(t *testing.T) {
+	setupProject(t, testConfigWithAliases)
+	executeCmd(t, "up")
+	opened := captureOpenBrowser(t)
+
+	output := executeCmd(t, "open", "worship", "--json")
+
+	if len(*opened) != 1 {
+		t.Fatalf("opened %d URLs, want 1", len(*opened))
+	}
+	if !strings.HasSuffix((*opened)[0], "://service-worship.testapp.test") {
+		t.Fatalf("opened URL = %q, want service hostname", (*opened)[0])
+	}
+
+	var result struct {
+		Opened []struct {
+			Kind     string `json:"kind"`
+			Service  string `json:"service"`
+			Alias    string `json:"alias,omitempty"`
+			Hostname string `json:"hostname"`
+			URL      string `json:"url"`
+			Port     int    `json:"port"`
+		} `json:"opened"`
+	}
+	unwrapJSON(t, output, &result)
+
+	if len(result.Opened) != 1 {
+		t.Fatalf("opened entries = %d, want 1", len(result.Opened))
+	}
+	got := result.Opened[0]
+	if got.Kind != "service" || got.Service != "worship" || got.Alias != "" || got.Hostname != "service-worship.testapp.test" || got.Port != 3001 {
+		t.Fatalf("opened entry = %+v, want service worship", got)
+	}
+}
+
+func TestOpen_UniqueAliasName(t *testing.T) {
+	setupProject(t, testConfigWithAliases)
+	executeCmd(t, "up")
+	opened := captureOpenBrowser(t)
+
+	output := executeCmd(t, "open", "admin", "--json")
+
+	if len(*opened) != 1 {
+		t.Fatalf("opened %d URLs, want 1", len(*opened))
+	}
+	if !strings.HasSuffix((*opened)[0], "://admin.testapp.test") {
+		t.Fatalf("opened URL = %q, want alias hostname", (*opened)[0])
+	}
+
+	var result struct {
+		Opened []struct {
+			Kind     string `json:"kind"`
+			Service  string `json:"service"`
+			Alias    string `json:"alias,omitempty"`
+			Hostname string `json:"hostname"`
+			Port     int    `json:"port"`
+		} `json:"opened"`
+	}
+	unwrapJSON(t, output, &result)
+
+	if len(result.Opened) != 1 {
+		t.Fatalf("opened entries = %d, want 1", len(result.Opened))
+	}
+	got := result.Opened[0]
+	if got.Kind != "alias" || got.Service != "web" || got.Alias != "admin" || got.Hostname != "admin.testapp.test" || got.Port != 3000 {
+		t.Fatalf("opened entry = %+v, want web admin alias", got)
+	}
+}
+
+func TestOpen_ExplicitAliasTarget(t *testing.T) {
+	setupProject(t, testConfigWithAliases)
+	executeCmd(t, "up")
+	opened := captureOpenBrowser(t)
+
+	output := executeCmd(t, "open", "web:worship", "--json")
+
+	if len(*opened) != 1 {
+		t.Fatalf("opened %d URLs, want 1", len(*opened))
+	}
+	if !strings.HasSuffix((*opened)[0], "://worship.testapp.test") {
+		t.Fatalf("opened URL = %q, want explicit alias hostname", (*opened)[0])
+	}
+
+	var result struct {
+		Opened []struct {
+			Kind     string `json:"kind"`
+			Service  string `json:"service"`
+			Alias    string `json:"alias,omitempty"`
+			Hostname string `json:"hostname"`
+			Port     int    `json:"port"`
+		} `json:"opened"`
+	}
+	unwrapJSON(t, output, &result)
+
+	if len(result.Opened) != 1 {
+		t.Fatalf("opened entries = %d, want 1", len(result.Opened))
+	}
+	got := result.Opened[0]
+	if got.Kind != "alias" || got.Service != "web" || got.Alias != "worship" || got.Hostname != "worship.testapp.test" || got.Port != 3000 {
+		t.Fatalf("opened entry = %+v, want web worship alias", got)
+	}
+}
+
+func TestOpen_AmbiguousAliasNameErrors(t *testing.T) {
+	setupProject(t, testConfigWithDuplicateAliasNames)
+	executeCmd(t, "up")
+	captureOpenBrowser(t)
+
+	_, err := executeCmdAllowError(t, "open", "admin")
+
+	if err == nil {
+		t.Fatal("expected ambiguous alias error")
+	}
+	if !strings.Contains(err.Error(), `alias "admin" is ambiguous`) {
+		t.Fatalf("error = %v, want ambiguous alias message", err)
+	}
+	if !strings.Contains(err.Error(), "web:admin") || !strings.Contains(err.Error(), "api:admin") {
+		t.Fatalf("error = %v, want explicit target suggestions", err)
+	}
+}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -113,11 +113,19 @@ Open HTTP services in the browser.
 ```bash
 outport open         # open default services (or all HTTP services)
 outport open web     # open a specific service
+outport open admin   # open a unique alias
+outport open web:admin  # open a specific service alias
 ```
 
-Opens HTTP services in your default browser. By default, opens all services with a `hostname`. If the `open` field is set in `outport.yml`, only the listed services are opened. Specify a service name to open just that one, regardless of the `open` list.
+Opens HTTP services in your default browser. By default, opens all services with a `hostname`. If the `open` field is set in `outport.yml`, only the listed services are opened.
+
+Specify a service name to open just that one, regardless of the `open` list. You can also specify an alias name shown in status output. Service names win over alias names, and duplicate alias names must be opened explicitly with `service:alias`.
 
 Works best with `.test` domains set up (`outport system start`).
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output opened target details as JSON |
 
 ### `outport qr`
 

--- a/skills/outport/SKILL.md
+++ b/skills/outport/SKILL.md
@@ -29,6 +29,8 @@ outport ports kill <svc>  # Kill process by service name or port number
 outport ports kill --orphans  # Kill all orphaned dev processes
 outport open              # Open HTTP services in browser
 outport open web          # Open a specific service
+outport open admin        # Open a unique alias
+outport open web:admin    # Open a specific service alias
 outport share             # Tunnel HTTP services to public URLs
 outport share web         # Tunnel a specific service
 outport qr                # Show QR codes for mobile device access


### PR DESCRIPTION
## Summary

- Allow `outport open` to target services, unique aliases, and explicit `service:alias` targets
- Add JSON success output for opened targets, including target kind and URL metadata
- Document the new call patterns in the README, command reference, and bundled Outport skill

## Behavior

Service names continue to win for bare targets. Bare alias names open only when they are unique across the project. Duplicate alias names return an ambiguity error with explicit `service:alias` suggestions.

Closes #122

## Validation

- `just lint`
- `just test`
- `go run . --help`
- `go run . open --help`
- `bin/deploy-docs`

Docs deployed to Cloudflare Pages:

- https://ea1351d6.outport-dev.pages.dev
- https://codex-open-alias-targets.outport-dev.pages.dev